### PR TITLE
Add Pairdrop

### DIFF
--- a/hosts/6194cicero-gmk-g3/pairdrop/compose.yml
+++ b/hosts/6194cicero-gmk-g3/pairdrop/compose.yml
@@ -3,6 +3,13 @@ services:
     image: linuxserver/pairdrop:1.11.2
     container_name: pairdrop
     hostname: pairdrop
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+      - RATE_LIMIT=${RATE_LIMIT}
+      - WS_FALLBACK=${WS_FALLBACK}
+      - DEBUG_MODE=${DEBUG_MODE}
     expose:
       - 3000
     healthcheck:


### PR DESCRIPTION
This pull request introduces a new Docker Compose configuration for deploying the PairDrop service on the `6194cicero-gmk-g3` host. The configuration sets up the PairDrop container with environment variables, health checks, resource limits, network settings, and logging options.

**New PairDrop Service Deployment:**

* Added a `compose.yml` file to define a `pairdrop` service using the `linuxserver/pairdrop:1.11.2` image, with environment variables, health checks, memory limits, and restart policy.
* Configured the service to join the external `caddy_caddy-net` network with a fixed IP address.
* Set up logging options and service labels for monitoring and integration with external tools.