### PR TITLE
Add Drawio

### DIFF
--- a/hosts/6194cicero-gmk-g3/drawio/compose.yml
+++ b/hosts/6194cicero-gmk-g3/drawio/compose.yml
@@ -1,0 +1,35 @@
+services:
+  drawio:
+    image: jgraph/drawio:28.1.2
+    container_name: drawio
+    hostname: drawio
+    expose:
+      - 8080
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+    networks:
+      caddy-net:
+        ipv4_address: 172.18.0.50
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    labels:
+      - 'wud.display.icon=sh:draw-io'
+      - 'wud.tag.include=^\d+\.\d+\.\d+$$'
+      - 'wud.link.template=https://github.com/jgraph/drawio/releases/tag/v$${major}.$${minor}.$${patch}'
+
+
+networks:
+  caddy-net:
+    name: caddy_caddy-net
+    external: true


### PR DESCRIPTION
This pull request introduces a new Docker Compose configuration for deploying the `drawio` service on the `6194cicero-gmk-g3` host. The configuration sets up the `drawio` container with resource limits, health checks, custom network settings, and logging options.

**Service addition and configuration:**

* Added a `compose.yml` file to define a `drawio` service using the `jgraph/drawio:28.1.2` image, with container name, hostname, port exposure, and restart policy.
* Configured a health check for the service to monitor its availability on port 8080.
* Set up resource limits (256MB memory), logging options, and deployment labels for integration with monitoring tools.

**Networking:**

* Connected the `drawio` service to the external `caddy_caddy-net` network with a static IPv4 address.