### PR TITLE
Add Caddy (gmkg3)

### DIFF
--- a/hosts/6194cicero-gmk-g3/caddy/compose.yml
+++ b/hosts/6194cicero-gmk-g3/caddy/compose.yml
@@ -14,6 +14,9 @@ services:
     # pull_policy: build
     pull_policy: never
     restart: unless-stopped
+    environment:
+      - PORKBUN_API_KEY=${PORKBUN_API_KEY}
+      - PORKBUN_API_SECRET_KEY=${PORKBUN_API_SECRET_KEY}
     expose:
       - 80
     ports:

--- a/hosts/6194cicero-gmk-g3/caddy/compose.yml
+++ b/hosts/6194cicero-gmk-g3/caddy/compose.yml
@@ -1,0 +1,64 @@
+services:
+  caddy:
+    # build:
+    #   context: .
+    #   dockerfile_inline: |
+    #     FROM caddy:2.10.0-builder-alpine AS builder
+    #     RUN xcaddy build --with github.com/caddy-dns/porkbun
+    #     FROM caddy:2.10.0-alpine
+    #     COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+    #     RUN apk add curl
+    image: caddy-porkbun:2.10.0-alpine
+    container_name: caddy
+    hostname: caddy
+    # pull_policy: build
+    pull_policy: never
+    restart: unless-stopped
+    expose:
+      - 80
+    ports:
+      - '443:443'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    env_file:
+      - stack.env
+    volumes:
+      - conf:/etc/caddy
+      - config:/config
+      - data:/data
+      - site:/srv:ro
+    networks:
+      caddy-net:
+        ipv4_address: 172.18.0.5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    labels:
+      - 'wud.display.icon=sh:caddy'
+      - 'wud.tag.include=caddy:^\d+\.\d+\.\d+-alpine'
+      - 'wud.link.template=https://github.com/caddyserver/caddy/releases/tag/v$${major}.$${minor}.$${patch}'
+
+
+volumes:
+  conf:
+  config:
+  data:
+  site:
+
+
+networks:
+  caddy-net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.0.0/24
+          gateway: 172.18.0.1

--- a/hosts/6194cicero-gmk-g3/caddy/compose.yml
+++ b/hosts/6194cicero-gmk-g3/caddy/compose.yml
@@ -27,8 +27,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-    env_file:
-      - stack.env
     volumes:
       - conf:/etc/caddy
       - config:/config


### PR DESCRIPTION
This pull request introduces a new `docker-compose` configuration for deploying a Caddy server with Porkbun DNS support in the `hosts/6194cicero-gmk-g3/caddy/compose.yml` file. The configuration sets up the Caddy service with custom image, environment variables, health checks, volume mounts, and network settings for robust and secure deployment.

Key additions in this pull request:

**Caddy Service Configuration:**

* Added a `caddy` service using a custom image (`caddy-porkbun:2.10.0-alpine`) with environment variables for Porkbun API integration and a health check endpoint.
* Configured the service to expose port 80 and map port 443, with restart policy, resource limits, logging options, and deployment labels for monitoring and management.

**Volumes and Networking:**

* Defined named volumes (`conf`, `config`, `data`, `site`) for persistent storage and site content.
* Established a custom network (`caddy-net`) with static IP addressing and subnet configuration for the Caddy container.