### PR TITLE
Add nebula-sync

### DIFF
--- a/hosts/6194cicero-gmk-g3/nebula-sync/compose.yml
+++ b/hosts/6194cicero-gmk-g3/nebula-sync/compose.yml
@@ -1,0 +1,48 @@
+services:
+  nebula-sync:
+    image: ghcr.io/lovelaze/nebula-sync:v0.11.0
+    container_name: nebula-sync
+    hostname: nebula-sync
+    environment:
+      - PRIMARY=${PRIMARY}
+      - REPLICAS=${REPLICAS}
+      - RUN_GRAVITY=${RUN_GRAVITY}
+      - CRON=${CRON}
+      - FULL_SYNC=${FULL_SYNC}
+      - SYNC_CONFIG_DNS=${SYNC_CONFIG_DNS}
+      - SYNC_CONFIG_DHCP=${SYNC_CONFIG_DHCP}
+      - SYNC_CONFIG_NTP=${SYNC_CONFIG_NTP}
+      - SYNC_CONFIG_RESOLVER=${SYNC_CONFIG_RESOLVER}
+      - SYNC_CONFIG_DATABASE=${SYNC_CONFIG_DATABASE}
+      - SYNC_CONFIG_MISC=${SYNC_CONFIG_MISC}
+      - SYNC_CONFIG_DEBUG=${SYNC_CONFIG_DEBUG}
+      - SYNC_GRAVITY_DHCP_LEASES=${SYNC_GRAVITY_DHCP_LEASES}
+      - SYNC_GRAVITY_GROUP=${SYNC_GRAVITY_GROUP}
+      - SYNC_GRAVITY_AD_LIST=${SYNC_GRAVITY_AD_LIST}
+      - SYNC_GRAVITY_AD_LIST_BY_GROUP=${SYNC_GRAVITY_AD_LIST_BY_GROUP}
+      - SYNC_GRAVITY_DOMAIN_LIST=${SYNC_GRAVITY_DOMAIN_LIST}
+      - SYNC_GRAVITY_DOMAIN_LIST_BY_GROUP=${SYNC_GRAVITY_DOMAIN_LIST_BY_GROUP}
+      - SYNC_GRAVITY_CLIENT=${SYNC_GRAVITY_CLIENT}
+      - SYNC_GRAVITY_CLIENT_BY_GROUP=${SYNC_GRAVITY_CLIENT_BY_GROUP}
+      - SYNC_CONFIG_DNS_EXCLUDE=${SYNC_CONFIG_DNS_EXCLUDE}
+    restart: unless-stopped
+    networks:
+      caddy-net:
+        ipv4_address: 172.18.0.9
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "128m"
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    labels:
+      - 'wud.tag.include=^v\d+\.\d+\.\d+$$'
+      - 'wud.link.template=https://github.com/lovelaze/nebula-sync/releases/tag/v$${major}.$${minor}.$${patch}'
+
+
+networks:
+  caddy-net:
+    name: caddy_caddy-net
+    external: true


### PR DESCRIPTION
This pull request introduces a new `docker-compose` configuration for deploying the `nebula-sync` service. The configuration defines environment variables, resource limits, networking, logging, and deployment options to ensure the service runs reliably and integrates with the existing infrastructure.

Service addition and configuration:

* Added a new `nebula-sync` service definition in `compose.yml`, specifying the Docker image, environment variables, resource limits, restart policy, and labels for update tracking.
* Configured the service to use the external `caddy-net` network with a fixed IPv4 address and set up logging options to manage log file size.
* Defined deployment resource limits to restrict memory usage to 128MB.
* Added labels for version tracking and linking to release notes on GitHub.
* Declared the external `caddy-net` network for service connectivity.