### PR TITLE
Add Speedtest

### DIFF
--- a/hosts/6194cicero-gmk-g3/speedtest/compose.yml
+++ b/hosts/6194cicero-gmk-g3/speedtest/compose.yml
@@ -15,6 +15,7 @@ services:
       - SPEEDTEST_SCHEDULE=${SPEEDTEST_SCHEDULE}
       - SPEEDTEST_SERVERS=${SPEEDTEST_SERVERS}
       - DISPLAY_TIMEZONE=${DISPLAY_TIMEZONE}
+      - PRUNE_RESULTS_OLDER_THAN=${PRUNE_RESULTS_OLDER_THAN}
     restart: unless-stopped
     volumes:
       - data:/config

--- a/hosts/6194cicero-gmk-g3/speedtest/compose.yml
+++ b/hosts/6194cicero-gmk-g3/speedtest/compose.yml
@@ -1,0 +1,50 @@
+services:
+  speedtest:
+    image: linuxserver/speedtest-tracker:1.6.6
+    container_name: speedtest
+    hostname: speedtest
+    expose:
+      - 80
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+      - APP_KEY=${APP_KEY}
+      - APP_URL=${APP_URL}
+      - DB_CONNECTION=${DB_CONNECTION}
+      - SPEEDTEST_SCHEDULE=${SPEEDTEST_SCHEDULE}
+      - SPEEDTEST_SERVERS=${SPEEDTEST_SERVERS}
+      - DISPLAY_TIMEZONE=${DISPLAY_TIMEZONE}
+    restart: unless-stopped
+    volumes:
+      - data:/config
+    # healthcheck:
+    #   test: ["CMD-SHELL", "curl -f http://localhost:<xxx> || exit 1"]
+    #   interval: 1m30s
+    #   timeout: 10s
+    #   retries: 5
+    #   start_period: 10s
+    networks:
+      caddy-net:
+        ipv4_address: 172.18.0.70
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    labels:
+      - 'wud.display.icon=sh:speedtest-tracker'
+      - 'wud.tag.include=^\d+\.\d+\.\d+$$'
+      - 'wud.link.template=https://github.com/alexjustesen/speedtest-tracker/releases/tag/v$${major}.$${minor}.$${patch}'
+
+networks:
+  caddy-net:
+    name: caddy_caddy-net
+    external: true
+
+
+volumes:
+  data:


### PR DESCRIPTION
This pull request introduces a new Docker Compose configuration for deploying the Speedtest Tracker service. The configuration sets up the container with environment variables, persistent storage, custom network settings, and resource limits to ensure reliable operation.

**Addition of Speedtest Tracker Service:**

- Added a new `compose.yml` file to configure the `speedtest` service using the `linuxserver/speedtest-tracker:1.6.6` image, specifying environment variables, persistent volume mapping, restart policy, and resource limits.
- Configured the service to join the external `caddy-net` Docker network with a static IP address, supporting integration with other services on the same network.
- Set up logging options and deployment resource constraints to manage disk usage and memory consumption for the container.
- Added labels for integration with Watchtower Update Display (WUD) for version tracking and release links.
- Defined a persistent `data` volume for configuration storage, ensuring data is retained across container restarts.