### PR TITLE
Add Vaultwarden

### DIFF
--- a/hosts/6194cicero-raspberrypi/vaultwarden/compose.yml
+++ b/hosts/6194cicero-raspberrypi/vaultwarden/compose.yml
@@ -1,0 +1,37 @@
+services:
+  vaultwarden:
+    image: vaultwarden/server:1.34.3-alpine
+    container_name: vaultwarden
+    hostname: vaultwarden
+    expose:
+      - 80
+    environment:
+      - DOMAIN=${DOMAIN}
+    restart: unless-stopped
+    volumes:
+      - data:/data/
+    networks:
+      pihole-net:
+        ipv4_address: 172.18.0.5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    labels:
+      - 'wud.display.icon=sh:vaultwarden'
+      - 'wud.tag.include=^\d+\.\d+\.\d+-alpine'
+      - 'wud.link.template=https://github.com/dani-garcia/vaultwarden/releases/tag/$${major}.$${minor}.$${patch}'
+
+
+networks:
+  pihole-net:
+    name: pihole_docker_pihole-net
+    external: true
+
+
+volumes:
+  data:


### PR DESCRIPTION
This pull request introduces a new `compose.yml` configuration for deploying the `vaultwarden` password manager on the Raspberry Pi host. The configuration sets up the service with appropriate networking, persistent storage, environment variables, resource limits, and logging options.

Key additions in this pull request:

**Vaultwarden Service Setup:**
* Added a `vaultwarden` service using the `vaultwarden/server:1.34.3-alpine` image, exposing port 80, setting environment variables, and configuring restart policy and resource limits.
* Configured persistent storage by mounting a named volume (`data:/data/`) for Vaultwarden data.

**Networking:**
* Attached the `vaultwarden` service to an external Docker network (`pihole_docker_pihole-net`) with a static IP address for integration with other services.

**Logging and Metadata:**
* Set up JSON-file logging with a size limit and added labels for integration with Watchtower Update Display (WUD) for monitoring and update notifications.