### PR TITLE
Add homer

### DIFF
--- a/hosts/6194cicero-raspberrypi/homer/compose.yml
+++ b/hosts/6194cicero-raspberrypi/homer/compose.yml
@@ -1,0 +1,38 @@
+services:
+  homer:
+    image: b4bz/homer:v25.05.2
+    container_name: homer
+    hostname: homer
+    expose:
+      - 8080
+    user: 1000:1000
+    environment:
+      - INIT_ASSETS=1
+    volumes:
+      - assets:/www/assets
+    restart: unless-stopped
+    networks:
+      pihole-net:
+        ipv4_address: 172.18.0.40
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    labels:
+      - 'wud.display.icon=sh:homer'
+      - 'wud.tag.include=^\d+(?:\.\d{1,2})?\.\d+$$'
+      - 'wud.link.template=https://github.com/bastienwirtz/homer/releases/tag/$${raw}'
+
+
+networks:
+  pihole-net:
+    name: pihole_docker_pihole-net
+    external: true
+
+
+volumes:
+  assets:


### PR DESCRIPTION
This pull request introduces a new `docker-compose` configuration for deploying the Homer dashboard service on the Raspberry Pi host. The configuration defines service parameters, networking, volumes, and resource limits to ensure proper operation and integration with the existing `pihole-net` network.

Service definition and configuration:

* Added a new `homer` service using the `b4bz/homer:v25.05.2` image, with environment variables, persistent volume for assets, and resource limits set to 64MB memory.
* Configured the `homer` service to join the external `pihole_docker_pihole-net` network with a static IP address (`172.18.0.40`).
* Set up logging options and deployment labels for better monitoring and integration with update detection tools.
* Defined an external network (`pihole-net`) and a persistent volume (`assets`) for the service.