### PR TITLE
Add authelia

### DIFF
--- a/hosts/6194cicero-raspberrypi/authelia/compose.yml
+++ b/hosts/6194cicero-raspberrypi/authelia/compose.yml
@@ -2,7 +2,7 @@ services:
   authelia:
     container_name: authelia
     hostname: authelia
-    image: authelia/authelia:4.39.7
+    image: authelia/authelia:4.39.8
     restart: unless-stopped
     expose:
       - 9091


### PR DESCRIPTION
This pull request introduces a new `compose.yml` file to set up the Authelia authentication service on the Raspberry Pi host. The configuration defines the Authelia container, its environment, networking, secrets management, and health checks, preparing it for secure and reliable deployment.

Container setup and configuration:

* Added a new `authelia` service definition in `compose.yml`, specifying the image version, container/network settings, environment variables for secrets, and a healthcheck to monitor service status.
* Configured persistent storage using `config` and `secrets` Docker volumes for Authelia's configuration and secret files.

Networking and integration:

* Connected the Authelia container to the external `pihole-net` Docker network with a static IP address, facilitating integration with other services on the same network.

Logging and resource management:

* Set up logging options and a memory limit to manage container resource usage and log size.

Service discovery and monitoring:

* Added labels to the container for use with external update monitoring tools (e.g., Watchtower or WUD) to track versioning and provide release links.