### PR TITLE
Update dependabot schedule - cronjob

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,6 @@ updates:
     directories:
       - "/hosts/*/*"
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "30 11 * * *"
+      timezone: "America/New_York"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to use a scheduled cron job for updates instead of the default daily interval.

Dependabot schedule changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R14): Changed the update schedule from "daily" to a specific cron job at 11:30 AM America/New_York time by adding `interval: "cron"`, `cronjob`, and `timezone` fields.