### PR TITLE
Update dependabot exclude paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
   - package-ecosystem: "docker-compose"
     directories:
       - "/hosts/*/*"
+    exclude-paths:
+      - "/hosts/*/caddy"
     schedule:
       interval: "cron"
       cronjob: "30 11 * * *"


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. The change excludes the `/hosts/*/caddy` directories from Docker Compose dependency updates.

- Dependabot will now ignore `/hosts/*/caddy` paths when checking for Docker Compose dependency updates in `.github/dependabot.yml`.