### PR TITLE
Update dependabot - exclude path syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directories:
       - "/hosts/*/*"
     exclude-paths:
-      - "/hosts/*/caddy"
+      - "hosts/*/caddy"
     schedule:
       interval: "cron"
       cronjob: "30 11 * * *"


### PR DESCRIPTION
This pull request makes a minor update to the `.github/dependabot.yml` configuration file, specifically correcting the path pattern used to exclude certain directories from Dependabot updates.

* Fixed the `exclude-paths` pattern by removing the leading slash to ensure that `hosts/*/caddy` directories are properly excluded from Dependabot monitoring.