### PR TITLE
Update dependabot - remove exclude for ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: "docker-compose"
     directories:
       - "/hosts/*/*"
-    exclude-paths:
-      - "hosts/*/caddy"
+    ignore:
+      - dependency-name: "caddy-*:*" 
     schedule:
       interval: "cron"
       cronjob: "30 11 * * *"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to improve how updates for Caddy-related dependencies are managed in Docker Compose directories. Instead of excluding the Caddy directory by path, it now uses a dependency name pattern to ignore all Caddy-related dependencies.

Dependabot configuration improvements:

* Changed from excluding the `hosts/*/caddy` directory by path to ignoring all dependencies with names matching the pattern `caddy-*:*` for Docker Compose updates in `.github/dependabot.yml`.