### PR TITLE
Update dependabot - ignore syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directories:
       - "/hosts/*/*"
     ignore:
-      - dependency-name: "caddy-*:*" 
+      - dependency-name: "caddy-*" 
     schedule:
       interval: "cron"
       cronjob: "30 11 * * *"


### PR DESCRIPTION
This pull request makes a minor update to the `.github/dependabot.yml` configuration, correcting the `dependency-name` pattern for ignored dependencies.

* Configuration update:
  * [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R12): Fixed the `dependency-name` pattern for ignored dependencies by removing an extra colon.