### PR TITLE
Add portainer

### DIFF
--- a/hosts/6194cicero-raspberrypi/portainer/compose.yml
+++ b/hosts/6194cicero-raspberrypi/portainer/compose.yml
@@ -1,0 +1,39 @@
+services:
+  portainer:
+    image: portainer/portainer-ce:2.33.1-alpine
+    container_name: portainer
+    restart: unless-stopped
+#    ports:
+#      - 9000:9000
+    expose:
+      - 9000  # HTTP port
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:9000 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    networks:
+      pihole-net:
+        ipv4_address: 172.18.0.70
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    labels:
+      - 'wud.display.icon=sh:portainer'
+      - 'wud.tag.include=^\d+\.\d+\.\d+-alpine$$'
+      - 'wud.link.template=https://github.com/portainer/portainer/releases/tag/$${major}.$${minor}.$${patch}'
+
+
+volumes:
+  portainer_data:
+
+
+networks:
+  pihole-net:
+    name: pihole_docker_pihole-net
+    external: true


### PR DESCRIPTION
This pull request adds a new Docker Compose configuration for running Portainer CE on a Raspberry Pi host. The configuration sets up the Portainer service with proper networking, health checks, persistent storage, and logging options.

**New Portainer service setup:**

* Added a `portainer` service using the `portainer/portainer-ce:2.33.1-alpine` image, configured to restart unless stopped.
* Exposes port 9000 for HTTP access and mounts Docker socket and a persistent data volume (`portainer_data`).
* Includes a healthcheck to verify service availability on port 9000.
* Connects the service to an external network (`pihole-net`) with a static IP address.
* Configures logging options and adds labels for display, tag filtering, and release link templating.

**Supporting configuration:**

* Defines the `portainer_data` volume for persistent storage.
* References the external `pihole-net` network for service connectivity.