### PR TITLE
Add caddy custom Dockerfile, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
       interval: "cron"
       cronjob: "30 11 * * *"
       timezone: "America/New_York"
+  - package-ecosystem: "docker"
+    directories:
+      - "/Dockerfiles/*"
+    schedule:
+      interval: "cron"
+      cronjob: "35 11 * * 1"
+      timezone: "America/New_York"

--- a/Dockerfiles/caddy/Dockerfile
+++ b/Dockerfiles/caddy/Dockerfile
@@ -1,0 +1,9 @@
+# Require build arg
+FROM caddy:2.10.0-builder-alpine AS builder
+ENV GODEBUG=netdns=go
+
+RUN xcaddy build --with github.com/caddy-dns/porkbun
+
+FROM caddy:2.10.0-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+RUN apk add --no-cache curl


### PR DESCRIPTION
This pull request introduces automated dependency updates for Dockerfiles and adds a new Dockerfile for building a custom Caddy image with Porkbun DNS support. The most important changes are grouped below:

Dependabot automation:

* Updated `.github/dependabot.yml` to enable scheduled dependency updates for Dockerfiles in the `/Dockerfiles/*` directory, running weekly on Mondays.

Dockerfile additions:

* Added `Dockerfiles/caddy/Dockerfile` to build a custom Caddy image using `xcaddy` with the `github.com/caddy-dns/porkbun` plugin, and included the `curl` utility in the final image.