### PR TITLE
Bump gmkg3 caddy version to 2.10.2

### DIFF
--- a/hosts/6194cicero-gmk-g3/caddy/compose.yml
+++ b/hosts/6194cicero-gmk-g3/caddy/compose.yml
@@ -3,12 +3,12 @@ services:
     # build:
     #   context: .
     #   dockerfile_inline: |
-    #     FROM caddy:2.10.0-builder-alpine AS builder
+    #     FROM caddy:2.10.2-builder-alpine AS builder
     #     RUN xcaddy build --with github.com/caddy-dns/porkbun
-    #     FROM caddy:2.10.0-alpine
+    #     FROM caddy:2.10.2-alpine
     #     COPY --from=builder /usr/bin/caddy /usr/bin/caddy
     #     RUN apk add curl
-    image: caddy-porkbun:2.10.0-alpine
+    image: caddy-porkbun:2.10.2-alpine
     container_name: caddy
     hostname: caddy
     # pull_policy: build


### PR DESCRIPTION
This pull request updates the Caddy service version in the `hosts/6194cicero-gmk-g3/caddy/compose.yml` file to use Caddy 2.10.2 instead of 2.10.0. This ensures the service runs on the latest minor release, which may include important bug fixes and improvements.

Caddy version update:

* Updated the Caddy Docker image and build instructions from version 2.10.0 to 2.10.2 for both the builder and runtime images, as well as the referenced image tag.