### PR TITLE
Bump rpi4 caddy version to 2.10.2

### DIFF
--- a/hosts/6194cicero-raspberrypi/caddy/compose.yml
+++ b/hosts/6194cicero-raspberrypi/caddy/compose.yml
@@ -3,12 +3,12 @@ services:
     # build:
     #   context: .
     #   dockerfile_inline: |
-    #     FROM caddy:2.10.0-builder-alpine AS builder
+    #     FROM caddy:2.10.2-builder-alpine AS builder
     #     RUN xcaddy build --with github.com/caddy-dns/porkbun
-    #     FROM caddy:2.10.0-alpine
+    #     FROM caddy:2.10.2-alpine
     #     COPY --from=builder /usr/bin/caddy /usr/bin/caddy
     #     RUN apk add curl
-    image: caddy-porkbun:2.10.0-alpine
+    image: caddy-porkbun:2.10.2-alpine
     container_name: caddy
     hostname: caddy
     # pull_policy: build


### PR DESCRIPTION
This pull request updates the Caddy service configuration to use version 2.10.2 instead of 2.10.0. The change ensures that both the build and runtime images for Caddy are aligned with the latest patch release.

Caddy version upgrade:

* Updated the base images and build instructions in the commented `build` section to use `caddy:2.10.2-builder-alpine` and `caddy:2.10.2-alpine` instead of version 2.10.0. (`hosts/6194cicero-raspberrypi/caddy/compose.yml`)
* Changed the `image` field to use `caddy-porkbun:2.10.2-alpine`, ensuring the service runs the newer version. (`hosts/6194cicero-raspberrypi/caddy/compose.yml`)