### PR TITLE
Add rpi4 pihole & unbound

### DIFF
--- a/hosts/6194cicero-raspberrypi/pihole/compose.yml
+++ b/hosts/6194cicero-raspberrypi/pihole/compose.yml
@@ -1,0 +1,91 @@
+# More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
+services:
+  pihole:
+    container_name: pihole-rpi4
+    hostname: pihole-rpi4
+    image: pihole/pihole:2025.08.0
+    # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      # - "67:67/udp" # Only required if you are using Pi-hole as your DHCP server
+      # - "8080:80/tcp"
+    expose:
+      - 80
+    environment:
+      - TZ=${TZ}
+      - FTLCONF_webserver_api_password=${FTLCONF_webserver_api_password}
+      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
+      - FTLCONF_dns_upstreams=${FTLCONF_dns_upstreams}
+      - FTLCONF_dns_listeningMode=${FTLCONF_dns_listeningMode}
+      - FTLCONF_dns_dnssec=${FTLCONF_dns_dnssec}
+      - FTLCONF_dns_bogusPriv=${FTLCONF_dns_bogusPriv}
+      - FTLCONF_dns_domainNeeded=${FTLCONF_dns_domainNeeded}
+    volumes:
+      - etc-pihole:/etc/pihole
+      - etc-dnsmasqd:/etc/dnsmasq.d
+    #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+    # cap_add:
+      # - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
+    restart: unless-stopped
+    networks:
+      pihole-net:
+        ipv4_address: 172.18.0.2
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    labels:
+      - 'wud.display.icon=sh:pi-hole'
+      - 'wud.tag.include=^\d+(?:\.\d{1,2})?\.\d+$$'
+      - 'wud.link.template=https://github.com/pi-hole/docker-pi-hole/releases/tag/$${raw}'
+
+
+  unbound:
+    container_name: unbound
+    hostname: unbound
+    image: klutchell/unbound:1.23.1
+    restart: unless-stopped
+    volumes:
+      - unbound-config:/opt/unbound/etc/unbound
+    healthcheck:
+      # Use the drill wrapper binary to reduce the exit codes to 0 or 1 for healthchecks
+      test: ['CMD', 'drill-hc', '@127.0.0.1', 'dnssec.works']
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
+    networks:
+      pihole-net:
+        ipv4_address: 172.18.0.3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    labels:
+      - 'wud.display.icon=sh:unbound'
+      - 'wud.tag.include=^\d+\.\d+\.\d+$$'
+      - 'wud.link.template=https://github.com/klutchell/unbound-docker/releases/tag/v$${major}.$${minor}.$${patch}'
+
+
+volumes:
+  etc-pihole:
+  etc-dnsmasqd:
+  unbound-config:
+
+
+networks:
+  pihole-net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.0.0/24
+          gateway: 172.18.0.1


### PR DESCRIPTION
This pull request introduces a new `compose.yml` configuration for deploying Pi-hole and Unbound services on a Raspberry Pi. The configuration sets up both containers with appropriate networking, environment variables, persistent storage, resource limits, and logging options to ensure reliable and maintainable operation.

**Service definitions and configuration:**

* Added a `pihole` service using the `pihole/pihole:2025.08.0` image, including environment variables for customization, port mappings for DNS, persistent volumes for data, and resource limits for stability.
* Added an `unbound` service using the `klutchell/unbound:1.23.1` image, with a healthcheck, persistent volume for configuration, and resource limits.

**Networking and storage setup:**

* Defined a custom Docker network (`pihole-net`) with static IP addresses for both services and a dedicated subnet/gateway.
* Configured named volumes for persistent data storage for Pi-hole, dnsmasq, and Unbound configuration.

**Operational enhancements:**

* Enabled logging options to manage log file sizes and added deployment resource limits for both services.
* Included custom labels for integration with update monitoring tools and service identification.