### PR TITLE
Bump Linuxserver Images Week 15 2026

### DIFF
--- a/hosts/6194cicero-gmk-g3/speedtest/compose.yml
+++ b/hosts/6194cicero-gmk-g3/speedtest/compose.yml
@@ -37,7 +37,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: speedtest
-    image: linuxserver/speedtest-tracker:v1.13.12-ls143
+    image: linuxserver/speedtest-tracker:v1.13.12-ls144@sha256:2af8df42ae2e32d162ce9230002e726789700e38e527e9c74a746aa983b86888
     labels:
       - 'wud.display.icon=sh:speedtest-tracker'
       - 'wud.tag.include=^v\d+\.\d+\.\d+.*$$'

--- a/hosts/6194cicero-raspberrypi/portainer/compose.yml
+++ b/hosts/6194cicero-raspberrypi/portainer/compose.yml
@@ -97,7 +97,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: portainer-socket-proxy
-    image: linuxserver/socket-proxy:3.2.15-r0-ls75
+    image: linuxserver/socket-proxy:3.2.15-r0-ls76@sha256:a5a143133df569b6103bd555c18b3355d0def538272ab3c65936cc93ebe44368
     labels:
       - 'wud.tag.include=^\d+\.\d+\.\d+\-r\d\-ls\d+$$'
       - 'wud.link.template=https://github.com/linuxserver/docker-socket-proxy/releases/tag/$${raw}'

--- a/hosts/6194cicero-raspberrypi/wireguard/compose.yml
+++ b/hosts/6194cicero-raspberrypi/wireguard/compose.yml
@@ -43,7 +43,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: wireguard-ls
-    image: linuxserver/wireguard:1.0.20250521-r1-ls106
+    image: linuxserver/wireguard:1.0.20250521-r1-ls108@sha256:f85af86cac70a091523947a7208f77002ce14f14555797779497745e65dedd6f
     labels:
       - 'wud.display.icon=sh:wireguard'
       - 'wud.tag.include=^\d+\.\d+\.\d+\-r\d\-ls\d{3,}$$'

--- a/hosts/6194cicero-raspberrypi/wud/compose.yml
+++ b/hosts/6194cicero-raspberrypi/wud/compose.yml
@@ -123,7 +123,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: wud-socket-proxy
-    image: linuxserver/socket-proxy:3.2.15-r0-ls75
+    image: linuxserver/socket-proxy:3.2.15-r0-ls76@sha256:a5a143133df569b6103bd555c18b3355d0def538272ab3c65936cc93ebe44368
     labels:
       - 'wud.tag.include=^\d+\.\d+\.\d+\-r\d\-ls\d+$$'
       - 'wud.link.template=https://github.com/linuxserver/docker-socket-proxy/releases/tag/$${raw}'


### PR DESCRIPTION
Bump Linuxserver Images Week 15 2026

speedtest from v1.13.12-ls143 to v1.13.12-ls144
socket-proxy from 3.2.15-r0-ls75 to .2.15-r0-ls76
wireguard from 1.0.20250521-r1-ls106 to 1.0.20250521-r1-ls108