### PR TITLE
Update linuxserver image tags

### DIFF
--- a/hosts/6194cicero-gmk-g3/pairdrop/compose.yml
+++ b/hosts/6194cicero-gmk-g3/pairdrop/compose.yml
@@ -32,7 +32,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: pairdrop
-    image: linuxserver/pairdrop:v1.11.2-ls134
+    image: linuxserver/pairdrop:v1.11.2@sha256:32c219894ac351ebf76674e1d18b5da7a97f52f3ba96acd3a1063bcccdb7b69b
     labels:
       - 'wud.display.icon=sh:pairdrop'
       - 'wud.tag.include=^v\d+\.\d+\.\d+.*$$'

--- a/hosts/6194cicero-gmk-g3/speedtest/compose.yml
+++ b/hosts/6194cicero-gmk-g3/speedtest/compose.yml
@@ -37,7 +37,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: speedtest
-    image: linuxserver/speedtest-tracker:v1.13.12-ls144@sha256:2af8df42ae2e32d162ce9230002e726789700e38e527e9c74a746aa983b86888
+    image: linuxserver/speedtest-tracker:1.14.0@sha256:e119c2ace7661a14186f6c58d3a8777035456c764f836f00736359dd4cb88524
     labels:
       - 'wud.display.icon=sh:speedtest-tracker'
       - 'wud.tag.include=^v\d+\.\d+\.\d+.*$$'

--- a/hosts/6194cicero-raspberrypi/portainer/compose.yml
+++ b/hosts/6194cicero-raspberrypi/portainer/compose.yml
@@ -97,7 +97,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: portainer-socket-proxy
-    image: linuxserver/socket-proxy:3.2.15-r0-ls76@sha256:a5a143133df569b6103bd555c18b3355d0def538272ab3c65936cc93ebe44368
+    image: linuxserver/socket-proxy:3.2.15@sha256:2a37bf384164425fc7019fb5a27e125afc047a1763b2961eea9338c60e1e14f6
     labels:
       - 'wud.tag.include=^\d+\.\d+\.\d+\-r\d\-ls\d+$$'
       - 'wud.link.template=https://github.com/linuxserver/docker-socket-proxy/releases/tag/$${raw}'

--- a/hosts/6194cicero-raspberrypi/wireguard/compose.yml
+++ b/hosts/6194cicero-raspberrypi/wireguard/compose.yml
@@ -43,7 +43,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: wireguard-ls
-    image: linuxserver/wireguard:1.0.20250521-r1-ls108@sha256:f85af86cac70a091523947a7208f77002ce14f14555797779497745e65dedd6f
+    image: linuxserver/wireguard:1.0.20250521@sha256:8e505886ba5da6788f1b9dfc62a25e2f2c3a96e64e6528ef7278d7e1d6649bd2
     labels:
       - 'wud.display.icon=sh:wireguard'
       - 'wud.tag.include=^\d+\.\d+\.\d+\-r\d\-ls\d{3,}$$'

--- a/hosts/6194cicero-raspberrypi/wud/compose.yml
+++ b/hosts/6194cicero-raspberrypi/wud/compose.yml
@@ -123,7 +123,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: wud-socket-proxy
-    image: linuxserver/socket-proxy:3.2.15-r0-ls76@sha256:a5a143133df569b6103bd555c18b3355d0def538272ab3c65936cc93ebe44368
+    image: linuxserver/socket-proxy:3.2.15@sha256:2a37bf384164425fc7019fb5a27e125afc047a1763b2961eea9338c60e1e14f6
     labels:
       - 'wud.tag.include=^\d+\.\d+\.\d+\-r\d\-ls\d+$$'
       - 'wud.link.template=https://github.com/linuxserver/docker-socket-proxy/releases/tag/$${raw}'


### PR DESCRIPTION
Swap linuxserver image tags to use X.X.X version (with digest) to ensure that renovate properly detects image updates.