### PR TITLE
Fix image tag format for pairdrop service in compose.yml

### DIFF
--- a/hosts/6194cicero-gmk-g3/pairdrop/compose.yml
+++ b/hosts/6194cicero-gmk-g3/pairdrop/compose.yml
@@ -32,7 +32,7 @@ services:
       retries: 3
       start_period: 10s
     hostname: pairdrop
-    image: linuxserver/pairdrop:v1.11.2@sha256:32c219894ac351ebf76674e1d18b5da7a97f52f3ba96acd3a1063bcccdb7b69b
+    image: linuxserver/pairdrop:1.11.2@sha256:32c219894ac351ebf76674e1d18b5da7a97f52f3ba96acd3a1063bcccdb7b69b
     labels:
       - 'wud.display.icon=sh:pairdrop'
       - 'wud.tag.include=^v\d+\.\d+\.\d+.*$$'


### PR DESCRIPTION
Update image tag from incorrect `v1.11.2` to `1.11.2`