### PR TITLE
Add terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.*
+**/*.tfplan
+**/*.tfvars
+**/*.tfvars.json
+**/*.auto.tfvars
+**/crash.log
+**/crash.*.log
+**/override.tf
+**/override.tf.json
+**/*_override.tf
+**/*_override.tf.json
+.terraformrc
+terraform.rc
+
+!**/*.tfvars.example

--- a/terraform/modules/portainer-stack/main.tf
+++ b/terraform/modules/portainer-stack/main.tf
@@ -1,0 +1,35 @@
+resource "portainer_stack" "this" {
+  name            = var.name
+  deployment_type = var.deployment_type
+  method          = "repository"
+  endpoint_id     = var.endpoint_id
+
+  repository_url            = var.repository_url
+  repository_reference_name = var.repository_reference_name
+  file_path_in_repository   = var.file_path_in_repository
+
+  additional_files              = var.additional_files
+  active                        = var.active
+  authorized_teams              = var.authorized_teams
+  authorized_users              = var.authorized_users
+  force_update                  = var.force_update
+  git_repository_authentication = var.git_repository_authentication
+  ownership                     = var.ownership
+  prune                         = var.prune
+  pull_image                    = var.pull_image
+  repository_git_credential_id  = var.repository_git_credential_id
+  stack_webhook                 = var.stack_webhook
+  support_relative_path         = var.support_relative_path
+  tlsskip_verify                = var.tlsskip_verify
+  update_interval               = var.update_interval
+
+  dynamic "env" {
+    for_each = var.env
+
+    content {
+      name  = env.key
+      value = env.value
+    }
+  }
+}
+

--- a/terraform/modules/portainer-stack/outputs.tf
+++ b/terraform/modules/portainer-stack/outputs.tf
@@ -1,0 +1,16 @@
+output "id" {
+  description = "Portainer stack ID."
+  value       = portainer_stack.this.id
+}
+
+output "resource_control_id" {
+  description = "Portainer resource control ID for the stack."
+  value       = portainer_stack.this.resource_control_id
+}
+
+output "webhook_url" {
+  description = "Portainer stack webhook URL, when stack webhooks are enabled."
+  value       = portainer_stack.this.webhook_url
+  sensitive   = true
+}
+

--- a/terraform/modules/portainer-stack/variables.tf
+++ b/terraform/modules/portainer-stack/variables.tf
@@ -1,0 +1,131 @@
+variable "name" {
+  description = "Portainer stack name."
+  type        = string
+}
+
+variable "deployment_type" {
+  description = "Portainer stack deployment type."
+  type        = string
+  default     = "standalone"
+
+  validation {
+    condition     = contains(["standalone", "swarm", "kubernetes"], var.deployment_type)
+    error_message = "deployment_type must be one of: standalone, swarm, kubernetes."
+  }
+}
+
+variable "endpoint_id" {
+  description = "Portainer environment/endpoint ID."
+  type        = number
+}
+
+variable "repository_url" {
+  description = "Git repository URL Portainer should use for the stack."
+  type        = string
+}
+
+variable "repository_reference_name" {
+  description = "Git reference Portainer should track, for example refs/heads/main."
+  type        = string
+}
+
+variable "file_path_in_repository" {
+  description = "Path to the compose file in the Git repository."
+  type        = string
+}
+
+variable "additional_files" {
+  description = "Additional compose or manifest files in the Git repository."
+  type        = list(string)
+  default     = []
+}
+
+variable "active" {
+  description = "Whether the stack should be running."
+  type        = bool
+  default     = true
+}
+
+variable "authorized_teams" {
+  description = "Portainer team IDs allowed when ownership is restricted."
+  type        = set(number)
+  default     = []
+}
+
+variable "authorized_users" {
+  description = "Portainer user IDs allowed when ownership is restricted."
+  type        = set(number)
+  default     = []
+}
+
+variable "env" {
+  description = "Stack environment variables configured in Portainer."
+  type        = map(string)
+  default     = {}
+}
+
+variable "force_update" {
+  description = "Force Portainer to redeploy the stack on update."
+  type        = bool
+  default     = false
+}
+
+variable "git_repository_authentication" {
+  description = "Whether Portainer should authenticate to the Git repository."
+  type        = bool
+  default     = false
+}
+
+variable "ownership" {
+  description = "Portainer stack ownership mode."
+  type        = string
+  default     = "administrators"
+
+  validation {
+    condition     = contains(["public", "administrators", "restricted", "private"], var.ownership)
+    error_message = "ownership must be one of: public, administrators, restricted, private."
+  }
+}
+
+variable "prune" {
+  description = "Remove services no longer present in the compose file."
+  type        = bool
+  default     = true
+}
+
+variable "pull_image" {
+  description = "Pull images when Portainer updates the stack."
+  type        = bool
+  default     = false
+}
+
+variable "repository_git_credential_id" {
+  description = "Existing Portainer Git credential ID to use for repository authentication."
+  type        = number
+  default     = null
+}
+
+variable "stack_webhook" {
+  description = "Enable the Portainer stack webhook."
+  type        = bool
+  default     = false
+}
+
+variable "support_relative_path" {
+  description = "Enable Portainer support for resolving relative paths."
+  type        = bool
+  default     = false
+}
+
+variable "tlsskip_verify" {
+  description = "Skip TLS verification when Portainer fetches the Git repository."
+  type        = bool
+  default     = false
+}
+
+variable "update_interval" {
+  description = "Portainer GitOps polling interval, for example 5m. Use null to leave unset."
+  type        = string
+  default     = "1h"
+}
+

--- a/terraform/modules/portainer-stack/versions.tf
+++ b/terraform/modules/portainer-stack/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    portainer = {
+      source = "portainer/portainer"
+    }
+  }
+}
+

--- a/terraform/portainer/.terraform.lock.hcl
+++ b/terraform/portainer/.terraform.lock.hcl
@@ -1,11 +1,22 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/portainer/portainer" {
+provider "registry.opentofu.org/portainer/portainer" {
   version     = "1.31.1"
   constraints = "1.31.1"
   hashes = [
+    "h1:3LZbDxKKS9Yovj/vBhNKFKl4xIu6nyS4byB/l/foXGg=",
+    "h1:49P2VjTsKz/uzw0L0Ds76nUDkBzs5CAlPO3c6FvP8Nw=",
+    "h1:59M9XqVLnslBfASJcmTyr6kJ3ZH2LakBQ6qS/dcxFIc=",
     "h1:EsZ4N2iUiI9p9W7Ha35sWHiQJ2y1R/4ZCWZP9WUep5A=",
+    "h1:RlwR9l8rVzB4ED7807hzMApxLb9OHDve0fnLKsazxJA=",
+    "h1:cy+CkUfwBvVr6tczcl2BcErByVlZCGFB9PZhBpvEVrA=",
+    "h1:eCAU6DnMyYILdhtmXSsnigiNFTcRAZoFOf6t+RLlQqw=",
+    "h1:nW267D84F6Uk40o35OScgKGMxBAvloZyDumsRRF3Abk=",
+    "h1:ucvKImfzvxdc3qfUciPptM1lCGw0kwcTPrmddURHgr4=",
+    "h1:vpzbjXGlIECDGlnn3r1gOMitsXywWMmD3MHDRlGbHwQ=",
+    "h1:vsXsr6sip3GRhFqwz1Bdf4eEHr13ObGMqClH+7hXeJM=",
+    "h1:y9svtkAQ22Qpi5aSyRZzZ8m5S8SjZeEGMDPeqTv59L0=",
     "zh:34f069c9f665227704bb49629ecf9e9096992e92d206024906d15ee8c6369bef",
     "zh:5c499a7a6f0df81db771491acf3996270232a97c9255742e02b8928f7ee81ae5",
     "zh:7924d281d1f93de8afa988969aacc0a82f19af039ff18e3b4179657638b2e2db",

--- a/terraform/portainer/.terraform.lock.hcl
+++ b/terraform/portainer/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/portainer/portainer" {
+  version     = "1.31.1"
+  constraints = "1.31.1"
+  hashes = [
+    "h1:EsZ4N2iUiI9p9W7Ha35sWHiQJ2y1R/4ZCWZP9WUep5A=",
+    "zh:34f069c9f665227704bb49629ecf9e9096992e92d206024906d15ee8c6369bef",
+    "zh:5c499a7a6f0df81db771491acf3996270232a97c9255742e02b8928f7ee81ae5",
+    "zh:7924d281d1f93de8afa988969aacc0a82f19af039ff18e3b4179657638b2e2db",
+    "zh:84500f5e0fc35799d60d4c85c4cfc9c2987690d934f2a0d9e9709345fe0d0fed",
+    "zh:9c050c29f9c1a4bdce78a5f835ad0161f74a3ed64ae83e1af8dd82f5e78c2a77",
+    "zh:b59fde28704dc5b43023b368b57f12073cce184b6494c0693c923a76293b5026",
+    "zh:bb3fe86cdf8c054ad51e32370950d455eac7112a767a7f6af9e563c78c64efff",
+    "zh:c43f6a924ef131f6a2ed43da7d332415653ca823f7cfe5ce1b5ce7df0bbd8bb2",
+    "zh:ca126682a829286692cc366ec0565b9acab73ac975abf1abea98fef9d6e72029",
+    "zh:ec8b6106974f4cd6ba22a7210196b2b1866fd0536a5fe71f98a954d99de51df1",
+    "zh:f82443fdda7c945fa040561598c06523a2a8230c1f38dbc23b8a6c9e6ef2cbbb",
+    "zh:fb0babfb91ac70f41ae45b619b77e0670d7f0057fe246cc920405775a422a145",
+  ]
+}

--- a/terraform/portainer/README.md
+++ b/terraform/portainer/README.md
@@ -1,0 +1,201 @@
+# Portainer Terraform
+
+This Terraform root manages existing Portainer objects while leaving the Portainer stack itself as bootstrap infrastructure.
+
+The initial test import is the Draw.io stack on `6194cicero-gmk-g3`, backed by:
+
+```text
+hosts/6194cicero-gmk-g3/drawio/compose.yml
+```
+
+## Layout
+
+Stack behavior is shared in `stacks.tf`. Host-specific stack inventory lives in one file per host:
+
+```text
+stacks.tf
+stacks.6194cicero-gmk-g3.tf
+stacks.6194cicero-raspberrypi.tf
+```
+
+To add another stack, add an entry to the matching host file. The shared module block in `stacks.tf` will pick it up through `local.stacks`.
+
+## Configure
+
+Copy the example values into a local ignored file and fill in your real Portainer/repository settings:
+
+```shell
+cp terraform.tfvars.example local.auto.tfvars
+```
+
+Prefer environment variables for Portainer credentials:
+
+```shell
+export PORTAINER_API_KEY="ptr_..."
+```
+
+If the actual Portainer environment name differs from the repo host key, update:
+
+```hcl
+portainer_environment_names = {
+  "6194cicero-gmk-g3"      = "6194-cicero-gmk-g3"
+  "6194cicero-raspberrypi" = "6194-cicero-raspberrypi"
+}
+```
+
+If the existing stack uses a saved Portainer Git credential, set:
+
+```hcl
+git_repository_authentication = true
+repository_git_credential_id  = 1
+```
+
+## Docker Hub Registries
+
+Docker Hub registries are managed through `dockerhub_registries` and `dockerhub_registry_tokens`.
+Keep PATs in `local.auto.tfvars` or another secure variable source because they will also be stored in Terraform state.
+Each registry entry must include Portainer's registry `type`; Docker Hub is `6`.
+The registry map key must also exist in `dockerhub_registry_tokens`.
+
+```hcl
+dockerhub_registries = {
+  dockerhub_personal = {
+    name     = "Docker Hub - Primary"
+    type     = 6
+    url      = "docker.io"
+    username = "dockerhub-user"
+  }
+
+  dockerhub_dhi = {
+    name     = "Docker Hub - DHI"
+    type     = 6
+    url      = "your-dhi-registry-url"
+    username = "dockerhub-user"
+  }
+}
+
+dockerhub_registry_tokens = {
+  dockerhub_personal = "dckr_pat_..."
+  dockerhub_dhi      = "dckr_pat_..."
+}
+```
+
+If importing existing registries, use the registry ID from Portainer:
+
+```shell
+terraform import 'portainer_registry.dockerhub["dockerhub_personal"]' <REGISTRY_ID>
+terraform import 'portainer_registry.dockerhub["dockerhub_dhi"]' <REGISTRY_ID>
+```
+
+## Import Draw.io
+
+Initialize the provider:
+
+```shell
+terraform init
+```
+
+Find the existing Draw.io stack ID and endpoint ID in Portainer, then import it.
+The Portainer provider expects this import ID format:
+
+```text
+<endpoint_id>-<stack_id>-<deployment_type>[-<method>]
+```
+
+For Draw.io on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `52`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/drawio"].portainer_stack.this' '5-52-standalone-repository'
+```
+
+For Actual Budget on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `88`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/actual-budget"].portainer_stack.this' '5-88-standalone-repository'
+```
+
+For Caddy on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `57`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/caddy"].portainer_stack.this' '5-57-standalone-repository'
+```
+
+For Nebula Sync on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `58`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/nebula-sync"].portainer_stack.this' '5-58-standalone-repository'
+```
+
+For Pairdrop on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `50`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/pairdrop"].portainer_stack.this' '5-50-standalone-repository'
+```
+
+For Pi-hole on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `60`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/pihole"].portainer_stack.this' '5-60-standalone-repository'
+```
+
+For Speedtest on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `59`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/speedtest"].portainer_stack.this' '5-59-standalone-repository'
+```
+
+For Volume Backup on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `92`, standalone deployment, Git repository mode, and feature branch `refs/heads/add-docker-volume-backup-test-tzdata`:
+
+```shell
+terraform import 'module.stack["6194cicero-gmk-g3/volume-backup"].portainer_stack.this' '5-92-standalone-repository'
+```
+
+For Vaultwarden on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `71`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/vaultwarden"].portainer_stack.this' '22-71-standalone-repository'
+```
+
+For Authelia on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `72`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/authelia"].portainer_stack.this' '22-72-standalone-repository'
+```
+
+For Homer on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `73`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/homer"].portainer_stack.this' '22-73-standalone-repository'
+```
+
+For Caddy on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `74`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/caddy"].portainer_stack.this' '22-74-standalone-repository'
+```
+
+For WireGuard LS on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `84`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/wireguard-ls"].portainer_stack.this' '22-84-standalone-repository'
+```
+
+For Monitoring on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `86`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/monitoring"].portainer_stack.this' '22-86-standalone-repository'
+```
+
+For Pi-hole on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `90`, standalone deployment, and Git repository mode:
+
+```shell
+terraform import 'module.stack["6194cicero-raspberrypi/pihole"].portainer_stack.this' '22-90-standalone-repository'
+```
+
+Check drift before applying:
+
+```shell
+terraform plan
+```
+
+The first goal is a plan with no unexpected stack redeploy. If the plan wants to change repository settings, Git credentials, webhook settings, polling interval, ownership, `pull_image`, or `prune`, adjust the Terraform inputs to match the existing Portainer stack before applying.

--- a/terraform/portainer/README.md
+++ b/terraform/portainer/README.md
@@ -2,12 +2,6 @@
 
 This Terraform root manages existing Portainer objects while leaving the Portainer stack itself as bootstrap infrastructure.
 
-The initial test import is the Draw.io stack on `6194cicero-gmk-g3`, backed by:
-
-```text
-hosts/6194cicero-gmk-g3/drawio/compose.yml
-```
-
 ## Layout
 
 Stack behavior is shared in `stacks.tf`. Host-specific stack inventory lives in one file per host:
@@ -87,7 +81,7 @@ terraform import 'portainer_registry.dockerhub["dockerhub_personal"]' <REGISTRY_
 terraform import 'portainer_registry.dockerhub["dockerhub_dhi"]' <REGISTRY_ID>
 ```
 
-## Import Draw.io
+## Import existing stacks
 
 Initialize the provider:
 
@@ -95,101 +89,19 @@ Initialize the provider:
 terraform init
 ```
 
-Find the existing Draw.io stack ID and endpoint ID in Portainer, then import it.
+Find the existing stack ID and endpoint ID in Portainer, then import it.
 The Portainer provider expects this import ID format:
 
 ```text
 <endpoint_id>-<stack_id>-<deployment_type>[-<method>]
 ```
 
+### Example - Draw.io
+
 For Draw.io on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `52`, standalone deployment, and Git repository mode:
 
 ```shell
 terraform import 'module.stack["6194cicero-gmk-g3/drawio"].portainer_stack.this' '5-52-standalone-repository'
-```
-
-For Actual Budget on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `88`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/actual-budget"].portainer_stack.this' '5-88-standalone-repository'
-```
-
-For Caddy on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `57`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/caddy"].portainer_stack.this' '5-57-standalone-repository'
-```
-
-For Nebula Sync on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `58`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/nebula-sync"].portainer_stack.this' '5-58-standalone-repository'
-```
-
-For Pairdrop on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `50`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/pairdrop"].portainer_stack.this' '5-50-standalone-repository'
-```
-
-For Pi-hole on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `60`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/pihole"].portainer_stack.this' '5-60-standalone-repository'
-```
-
-For Speedtest on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `59`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/speedtest"].portainer_stack.this' '5-59-standalone-repository'
-```
-
-For Volume Backup on `6194cicero-gmk-g3`, using endpoint ID `5`, stack ID `92`, standalone deployment, Git repository mode, and feature branch `refs/heads/add-docker-volume-backup-test-tzdata`:
-
-```shell
-terraform import 'module.stack["6194cicero-gmk-g3/volume-backup"].portainer_stack.this' '5-92-standalone-repository'
-```
-
-For Vaultwarden on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `71`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/vaultwarden"].portainer_stack.this' '22-71-standalone-repository'
-```
-
-For Authelia on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `72`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/authelia"].portainer_stack.this' '22-72-standalone-repository'
-```
-
-For Homer on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `73`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/homer"].portainer_stack.this' '22-73-standalone-repository'
-```
-
-For Caddy on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `74`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/caddy"].portainer_stack.this' '22-74-standalone-repository'
-```
-
-For WireGuard LS on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `84`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/wireguard-ls"].portainer_stack.this' '22-84-standalone-repository'
-```
-
-For Monitoring on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `86`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/monitoring"].portainer_stack.this' '22-86-standalone-repository'
-```
-
-For Pi-hole on `6194cicero-raspberrypi`, using endpoint ID `22`, stack ID `90`, standalone deployment, and Git repository mode:
-
-```shell
-terraform import 'module.stack["6194cicero-raspberrypi/pihole"].portainer_stack.this' '22-90-standalone-repository'
 ```
 
 Check drift before applying:

--- a/terraform/portainer/custom_templates.tf
+++ b/terraform/portainer/custom_templates.tf
@@ -1,0 +1,14 @@
+resource "portainer_custom_template" "standard_compose" {
+  title       = "standard-docker-compose"
+  description = "Standard docker compose template, caddy-net network, numerous placeholders"
+  note        = "Managed by Terraform"
+
+  platform = 1 # Linux
+  type     = 2 # Compose
+
+  repository_url       = "https://github.com/mmichalak-swe/homelab-gitops"
+  repository_reference = "refs/heads/main"
+  compose_file_path    = "templates/portainer/standard-compose.yml"
+
+  tlsskip_verify = false
+}

--- a/terraform/portainer/data.tf
+++ b/terraform/portainer/data.tf
@@ -1,0 +1,6 @@
+data "portainer_environment" "host" {
+  for_each = var.portainer_environment_names
+
+  name = each.value
+}
+

--- a/terraform/portainer/outputs.tf
+++ b/terraform/portainer/outputs.tf
@@ -1,0 +1,21 @@
+output "stack_ids" {
+  description = "Managed Portainer stack IDs."
+  value = {
+    for key, stack in module.stack : key => stack.id
+  }
+}
+
+output "stack_webhook_urls" {
+  description = "Managed Portainer stack webhook URLs."
+  value = {
+    for key, stack in module.stack : key => stack.webhook_url
+  }
+  sensitive = true
+}
+
+output "dockerhub_registry_ids" {
+  description = "Managed Docker Hub registry IDs."
+  value = {
+    for key, registry in portainer_registry.dockerhub : key => registry.id
+  }
+}

--- a/terraform/portainer/provider.tf
+++ b/terraform/portainer/provider.tf
@@ -1,0 +1,8 @@
+provider "portainer" {
+  endpoint        = var.portainer_endpoint
+  api_key         = var.portainer_api_key
+  api_user        = var.portainer_api_user
+  api_password    = var.portainer_api_password
+  skip_ssl_verify = var.portainer_skip_ssl_verify
+}
+

--- a/terraform/portainer/registries.tf
+++ b/terraform/portainer/registries.tf
@@ -1,0 +1,10 @@
+resource "portainer_registry" "dockerhub" {
+  for_each = var.dockerhub_registries
+
+  authentication = each.value.authentication
+  name           = each.value.name
+  password       = var.dockerhub_registry_tokens[each.key]
+  type           = each.value.type
+  url            = each.value.url
+  username       = each.value.username
+}

--- a/terraform/portainer/stacks.6194cicero-gmk-g3.tf
+++ b/terraform/portainer/stacks.6194cicero-gmk-g3.tf
@@ -1,0 +1,61 @@
+locals {
+  stacks_6194cicero_gmk_g3 = {
+    "6194cicero-gmk-g3/actual-budget" = {
+      name                    = "actual-budget"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/actual-budget/compose.yml"
+      env                     = {}
+    }
+
+    "6194cicero-gmk-g3/caddy" = {
+      name                    = "caddy"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/caddy/compose.yml"
+      env                     = try(var.stack_env["6194cicero-gmk-g3/caddy"], {})
+    }
+
+    "6194cicero-gmk-g3/drawio" = {
+      name                    = "drawio"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/drawio/compose.yml"
+      env                     = {}
+    }
+
+    "6194cicero-gmk-g3/nebula-sync" = {
+      name                    = "nebula-sync"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/nebula-sync/compose.yml"
+      env                     = try(var.stack_env["6194cicero-gmk-g3/nebula-sync"], {})
+    }
+
+    "6194cicero-gmk-g3/pairdrop" = {
+      name                    = "pairdrop"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/pairdrop/compose.yml"
+      env                     = try(var.stack_env["6194cicero-gmk-g3/pairdrop"], {})
+    }
+
+    "6194cicero-gmk-g3/pihole" = {
+      name                    = "pihole"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/pihole/compose.yml"
+      env                     = try(var.stack_env["6194cicero-gmk-g3/pihole"], {})
+    }
+
+    "6194cicero-gmk-g3/speedtest" = {
+      name                    = "speedtest"
+      host                    = "6194cicero-gmk-g3"
+      file_path_in_repository = "hosts/6194cicero-gmk-g3/speedtest/compose.yml"
+      env                     = try(var.stack_env["6194cicero-gmk-g3/speedtest"], {})
+    }
+
+    "6194cicero-gmk-g3/volume-backup" = {
+      name                      = "volume-backup"
+      host                      = "6194cicero-gmk-g3"
+      repository_reference_name = lookup(var.stack_repository_reference_names, "6194cicero-gmk-g3/volume-backup", var.repository_reference_name)
+      file_path_in_repository   = "hosts/6194cicero-gmk-g3/volume-backup/compose.yml"
+      env                       = try(var.stack_env["6194cicero-gmk-g3/volume-backup"], {})
+      update_interval           = "24h"
+    }
+  }
+}

--- a/terraform/portainer/stacks.6194cicero-raspberrypi.tf
+++ b/terraform/portainer/stacks.6194cicero-raspberrypi.tf
@@ -1,0 +1,52 @@
+locals {
+  stacks_6194cicero_raspberrypi = {
+    "6194cicero-raspberrypi/authelia" = {
+      name                    = "authelia"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/authelia/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/authelia"], {})
+    }
+
+    "6194cicero-raspberrypi/caddy" = {
+      name                    = "caddy"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/caddy/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/caddy"], {})
+    }
+
+    "6194cicero-raspberrypi/homer" = {
+      name                    = "homer"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/homer/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/homer"], {})
+    }
+
+    "6194cicero-raspberrypi/monitoring" = {
+      name                    = "monitoring"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/monitoring/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/monitoring"], {})
+    }
+
+    "6194cicero-raspberrypi/pihole" = {
+      name                    = "pihole"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/pihole/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/pihole"], {})
+    }
+
+    "6194cicero-raspberrypi/vaultwarden" = {
+      name                    = "vaultwarden"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/vaultwarden/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/vaultwarden"], {})
+    }
+
+    "6194cicero-raspberrypi/wireguard-ls" = {
+      name                    = "wireguard-ls"
+      host                    = "6194cicero-raspberrypi"
+      file_path_in_repository = "hosts/6194cicero-raspberrypi/wireguard/compose.yml"
+      env                     = try(var.stack_env["6194cicero-raspberrypi/wireguard-ls"], {})
+    }
+  }
+}

--- a/terraform/portainer/stacks.tf
+++ b/terraform/portainer/stacks.tf
@@ -1,0 +1,32 @@
+locals {
+  stacks = merge(
+    local.stacks_6194cicero_gmk_g3,
+    local.stacks_6194cicero_raspberrypi,
+  )
+}
+
+module "stack" {
+  source = "../modules/portainer-stack"
+
+  for_each = local.stacks
+
+  name        = each.value.name
+  endpoint_id = tonumber(data.portainer_environment.host[each.value.host].id)
+
+  repository_url            = var.repository_url
+  repository_reference_name = try(each.value.repository_reference_name, var.repository_reference_name)
+  file_path_in_repository   = each.value.file_path_in_repository
+
+  env = each.value.env
+
+  force_update                  = try(each.value.force_update, var.stack_defaults.force_update)
+  git_repository_authentication = var.git_repository_authentication
+  ownership                     = try(each.value.ownership, var.stack_defaults.ownership)
+  prune                         = try(each.value.prune, var.stack_defaults.prune)
+  pull_image                    = try(each.value.pull_image, var.stack_defaults.pull_image)
+  repository_git_credential_id  = var.repository_git_credential_id
+  stack_webhook                 = try(each.value.stack_webhook, var.stack_defaults.stack_webhook)
+  support_relative_path         = try(each.value.support_relative_path, var.stack_defaults.support_relative_path)
+  tlsskip_verify                = try(each.value.tlsskip_verify, var.stack_defaults.tlsskip_verify)
+  update_interval               = try(each.value.update_interval, var.stack_defaults.update_interval)
+}

--- a/terraform/portainer/terraform.tfvars.example
+++ b/terraform/portainer/terraform.tfvars.example
@@ -1,0 +1,152 @@
+portainer_endpoint = "https://portainer.example.com"
+
+# Prefer PORTAINER_API_KEY in your shell or a local, ignored *.auto.tfvars file.
+# portainer_api_key = "ptr_..."
+
+repository_url            = "https://github.com/your-user/homelab-gitops.git"
+repository_reference_name = "refs/heads/main"
+
+stack_repository_reference_names = {
+  "6194cicero-gmk-g3/volume-backup" = "refs/heads/add-docker-volume-backup-test-tzdata"
+}
+
+dockerhub_registries = {
+  dockerhub_personal = {
+    name     = "Docker Hub - Primary"
+    # Portainer registry type 6 is Docker Hub.
+    type     = 6
+    url      = "docker.io"
+    username = ""
+  }
+
+  dockerhub_dhi = {
+    name     = "Docker Hub - DHI"
+    # Portainer registry type 6 is Docker Hub.
+    type     = 6
+    url      = "your-dhi-registry-url"
+    username = ""
+  }
+}
+
+dockerhub_registry_tokens = {
+  dockerhub_personal = ""
+  dockerhub_dhi      = ""
+}
+
+portainer_environment_names = {
+  "6194cicero-gmk-g3"      = "6194cicero-gmk-g3"
+  "6194cicero-raspberrypi" = "6194cicero-raspberrypi"
+}
+
+# If this repository is private, set these to match the existing Portainer stack.
+# git_repository_authentication = true
+# repository_git_credential_id  = 1
+
+stack_env = {
+  "6194cicero-gmk-g3/volume-backup" = {
+    TZ = "America/New_York"
+  }
+
+  "6194cicero-gmk-g3/caddy" = {
+    PORKBUN_API_KEY        = ""
+    PORKBUN_API_SECRET_KEY = ""
+  }
+
+  "6194cicero-gmk-g3/nebula-sync" = {
+    CRON        = ""
+    FULL_SYNC   = ""
+    PRIMARY     = ""
+    REPLICAS    = ""
+    RUN_GRAVITY = ""
+    TZ          = "America/New_York"
+  }
+
+  "6194cicero-gmk-g3/pairdrop" = {
+    DEBUG_MODE  = ""
+    RATE_LIMIT  = ""
+    TZ          = "America/New_York"
+    WS_FALLBACK = ""
+  }
+
+  "6194cicero-gmk-g3/pihole" = {
+    DNSMASQ_USER                   = ""
+    FTLCONF_dns_bogusPriv          = ""
+    FTLCONF_dns_dnssec             = ""
+    FTLCONF_dns_domainNeeded       = ""
+    FTLCONF_dns_listeningMode      = ""
+    FTLCONF_dns_upstreams          = ""
+    FTLCONF_webserver_api_password = ""
+    PIHOLE_GID                     = ""
+    PIHOLE_UID                     = ""
+    TZ                             = "America/New_York"
+  }
+
+  "6194cicero-gmk-g3/speedtest" = {
+    APP_KEY                  = ""
+    APP_URL                  = ""
+    DB_CONNECTION            = ""
+    DISPLAY_TIMEZONE         = "America/New_York"
+    PRUNE_RESULTS_OLDER_THAN = ""
+    SPEEDTEST_SCHEDULE       = ""
+    SPEEDTEST_SERVERS        = ""
+    TZ                       = "America/New_York"
+  }
+
+  "6194cicero-raspberrypi/vaultwarden" = {
+    DOMAIN = ""
+  }
+
+  "6194cicero-raspberrypi/authelia" = {
+    AUTHELIA_IDENTITY_VALIDATION_RESET_PASSWORD_JWT_SECRET_FILE = ""
+    AUTHELIA_SESSION_SECRET_FILE                               = ""
+    AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE                       = ""
+    TZ                                                         = "America/New_York"
+  }
+
+  "6194cicero-raspberrypi/caddy" = {
+    PORKBUN_API_KEY        = ""
+    PORKBUN_API_SECRET_KEY = ""
+  }
+
+  "6194cicero-raspberrypi/homer" = {
+    INIT_ASSETS = ""
+  }
+
+  "6194cicero-raspberrypi/monitoring" = {
+    GF_SECURITY_ADMIN_USER                    = ""
+    GF_SECURITY_ADMIN_PASSWORD                = ""
+    GF_USERS_ALLOW_SIGN_UP                    = ""
+    GF_PATHS_CONFIG                           = ""
+    GF_PATHS_DATA                             = ""
+    GF_PATHS_HOME                             = ""
+    GF_PATHS_LOGS                             = ""
+    GF_PATHS_PLUGINS                          = ""
+    GF_PATHS_PROVISIONING                     = ""
+    GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH = ""
+  }
+
+  "6194cicero-raspberrypi/pihole" = {
+    DNSMASQ_USER                   = ""
+    FTLCONF_dns_bogusPriv          = ""
+    FTLCONF_dns_dnssec             = ""
+    FTLCONF_dns_domainNeeded       = ""
+    FTLCONF_dns_listeningMode      = ""
+    FTLCONF_dns_upstreams          = ""
+    FTLCONF_webserver_api_password = ""
+    PIHOLE_GID                     = ""
+    PIHOLE_UID                     = ""
+    TZ                             = "America/New_York"
+  }
+
+  "6194cicero-raspberrypi/wireguard-ls" = {
+    ALLOWEDIPS                = ""
+    INTERNAL_SUBNET           = ""
+    LOG_CONFS                 = ""
+    PEERS                     = ""
+    PEERDNS                   = ""
+    PERSISTENTKEEPALIVE_PEERS = ""
+    SERVERPORT                = ""
+    SERVERURL                 = ""
+    TZ                        = "America/New_York"
+  }
+}

--- a/terraform/portainer/variables.tf
+++ b/terraform/portainer/variables.tf
@@ -1,0 +1,135 @@
+variable "portainer_endpoint" {
+  description = "Portainer API endpoint. Can also be set with PORTAINER_ENDPOINT."
+  type        = string
+  default     = null
+}
+
+variable "portainer_api_key" {
+  description = "Portainer API key. Prefer PORTAINER_API_KEY instead of committing this value."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "portainer_api_user" {
+  description = "Portainer username. Can also be set with PORTAINER_USER."
+  type        = string
+  default     = null
+}
+
+variable "portainer_api_password" {
+  description = "Portainer password. Prefer PORTAINER_PASSWORD instead of committing this value."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "portainer_skip_ssl_verify" {
+  description = "Skip TLS certificate verification for the Portainer API client."
+  type        = bool
+  default     = false
+}
+
+variable "repository_url" {
+  description = "Git repository URL that Portainer uses for stack deployments."
+  type        = string
+}
+
+variable "repository_reference_name" {
+  description = "Git reference that Portainer tracks for stack deployments."
+  type        = string
+  default     = "refs/heads/main"
+}
+
+variable "stack_repository_reference_names" {
+  description = "Per-stack Git references for stacks that do not track the global repository_reference_name."
+  type        = map(string)
+  default     = {}
+}
+
+variable "portainer_environment_names" {
+  description = "Map from repo host key to the matching Portainer environment name."
+  type        = map(string)
+
+  default = {
+    "6194cicero-gmk-g3"      = "6194cicero-gmk-g3"
+    "6194cicero-raspberrypi" = "6194cicero-raspberrypi"
+  }
+}
+
+variable "git_repository_authentication" {
+  description = "Whether Portainer should authenticate to the Git repository."
+  type        = bool
+  default     = false
+}
+
+variable "repository_git_credential_id" {
+  description = "Existing Portainer Git credential ID to use for repository authentication."
+  type        = number
+  default     = null
+}
+
+variable "dockerhub_registries" {
+  description = "Docker Hub registries to register in Portainer. The map key must also exist in dockerhub_registry_tokens. Use type 6 for Docker Hub."
+  type = map(object({
+    authentication = bool
+    name           = string
+    type           = number
+    username       = string
+    url            = optional(string, "docker.io")
+  }))
+  default = {}
+}
+
+variable "dockerhub_registry_tokens" {
+  description = "Docker Hub personal access tokens, keyed by dockerhub_registries key."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
+variable "stack_defaults" {
+  description = "Default behavior for Portainer Git-backed stacks."
+  type = object({
+    force_update          = bool
+    ownership             = string
+    prune                 = bool
+    pull_image            = bool
+    stack_webhook         = bool
+    support_relative_path = bool
+    tlsskip_verify        = bool
+    update_interval       = string
+  })
+
+  default = {
+    force_update          = false
+    ownership             = "administrators"
+    prune                 = true
+    pull_image            = false
+    stack_webhook         = false
+    support_relative_path = false
+    tlsskip_verify        = false
+    update_interval       = "1h"
+  }
+}
+
+variable "stack_env" {
+  description = "Per-stack environment variables configured in Portainer. Keep sensitive values in a local, ignored tfvars file or another secure variable source."
+  type        = map(map(string))
+
+  default = {
+    "6194cicero-gmk-g3/caddy"             = {}
+    "6194cicero-gmk-g3/nebula-sync"       = {}
+    "6194cicero-gmk-g3/pairdrop"          = {}
+    "6194cicero-gmk-g3/pihole"            = {}
+    "6194cicero-gmk-g3/speedtest"         = {}
+    "6194cicero-gmk-g3/volume-backup"     = {}
+    "6194cicero-raspberrypi/authelia"     = {}
+    "6194cicero-raspberrypi/caddy"        = {}
+    "6194cicero-raspberrypi/homer"        = {}
+    "6194cicero-raspberrypi/monitoring"   = {}
+    "6194cicero-raspberrypi/pihole"       = {}
+    "6194cicero-raspberrypi/vaultwarden"  = {}
+    "6194cicero-raspberrypi/wireguard-ls" = {}
+  }
+}

--- a/terraform/portainer/versions.tf
+++ b/terraform/portainer/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.15.0"
+
+  required_providers {
+    portainer = {
+      source  = "portainer/portainer"
+      version = "1.31.1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an OpenTofu/Terraform-managed Portainer configuration for the homelab.

## Changes

- Adds a reusable `portainer-stack` module for Git-backed Portainer stacks.
- Adds a `terraform/portainer` root module for managing:
  - Portainer stack resources across `6194cicero-gmk-g3` and `6194cicero-raspberrypi`
  - Docker Hub registry entries
  - A standard Docker Compose custom template
- Adds host-specific stack inventory files for 15 existing stacks.
- Adds example tfvars and README documentation for local configuration, imports, environment variables, registry tokens, and drift checks.
- Adds Terraform/OpenTofu ignore rules for state, plans, local tfvars, crash logs, and override files.