### PR TITLE
Add Renovate configuration for Terraform

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,33 +4,51 @@
   "timezone": "America/New_York",
   "dependencyDashboard": true,
   "updateNotScheduled": false,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "ignorePaths": ["hosts/**/caddy/**"],
   "includePaths": [
     ".github/**",
     "hosts/*/*/compose.yml",
     "hosts/*/*/compose.yaml",
-    "Dockerfiles/*/Dockerfile"
+    "Dockerfiles/*/Dockerfile",
+    "terraform/*/versions.tf"
   ],
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "description": "Approximate Dependabot's weekly GitHub Actions checks on Thursdays before 05:00 ET",
+      "description": "Update GitHub Actions weekly before 05:00 ET on Monday",
       "matchManagers": ["github-actions"],
-      "schedule": ["* 0-4 * * 4"]
+      "schedule": ["* 0-4 * * 1"]
     },
     {
-      "description": "Approximate Dependabot's weekday Docker Compose checks before 05:00 ET",
+      "description": "Update Docker Compose files on weekdays before 05:00 ET",
       "matchManagers": ["docker-compose"],
       "matchFileNames": ["hosts/*/*/compose.yml", "hosts/*/*/compose.yaml"],
       "schedule": ["* 0-4 * * 1-5"],
       "addLabels": ["docker_compose"]
     },
     {
-      "description": "Approximate Dependabot's weekly Dockerfile checks on Mondays before 05:00 ET",
+      "description": "Update Dockerfiles weekly before 05:00 ET on Monday",
       "matchManagers": ["dockerfile"],
       "matchFileNames": ["Dockerfiles/*/Dockerfile"],
       "schedule": ["* 0-4 * * 1"],
       "addLabels": ["docker"]
+    },
+    {
+      "description": "Resolve Terraform providers from the OpenTofu registry",
+      "matchDatasources": ["terraform-provider"],
+      "registryUrls": ["https://registry.opentofu.org"]
+    },
+    {
+      "description": "Update Terraform dependencies weekly before 05:00 ET on Monday",
+      "matchManagers": ["terraform"],
+      "matchFileNames": [
+        "terraform/*/versions.tf"
+      ],
+      "schedule": ["* 0-4 * * 1"],
+      "addLabels": ["terraform"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add Terraform dependency scanning for root-level `terraform/*/versions.tf` files.
- Configure Terraform provider lookups to use the OpenTofu registry.
- Enable Renovate lock file maintenance.
- Align Renovate package rule descriptions and schedules for GitHub Actions, Docker Compose, Dockerfiles, and Terraform updates.

## Validation

- Ran `jq empty .github/renovate.json`
- Ran `renovate-config-validator .github/renovate.json`

## Notes

Terraform updates are scoped to root-level `versions.tf` files, so `terraform/modules/portainer-stack/versions.tf` is not included unless it is moved under a direct `terraform/*/` stack path or the Renovate pattern is broadened.