### PR TITLE
Remove implicit OpenTofu registry configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,11 +37,6 @@
       "addLabels": ["docker"]
     },
     {
-      "description": "Resolve Terraform providers from the OpenTofu registry",
-      "matchDatasources": ["terraform-provider"],
-      "registryUrls": ["https://registry.opentofu.org"]
-    },
-    {
       "description": "Update Terraform dependencies weekly before 05:00 ET on Monday",
       "matchManagers": ["terraform"],
       "matchFileNames": [

--- a/terraform/portainer/versions.tf
+++ b/terraform/portainer/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     portainer = {
-      source  = "portainer/portainer"
+      source  = "registry.opentofu.org/portainer/portainer"
       version = "1.31.1"
     }
   }


### PR DESCRIPTION
## Summary

- Remove the Renovate-level Terraform provider registry override.
- Declare the OpenTofu registry directly in the Portainer provider source.
- Keep Terraform dependency updates scoped to `terraform/*/versions.tf`.

## Validation

- Ran `renovate-config-validator .github/renovate.json`
- Ran `tofu fmt -check terraform/portainer/versions.tf`

## Notes

The Portainer provider now uses the explicit source `registry.opentofu.org/portainer/portainer`, so registry selection is handled per provider instead of globally through Renovate.