### PR TITLE
Move Portainer OpenTofu state to AWS S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/*.tfstate
 **/*.tfstate.*
 **/*.tfplan
+**/*.tfbackend
 **/*.tfvars
 **/*.tfvars.*
 **/*.tfvars.json
@@ -22,3 +23,4 @@ terraform.rc
 tofu.rc
 
 !**/*.tfvars.example
+!**/*.tfbackend.example

--- a/opentofu/portainer/.terraform.lock.hcl
+++ b/opentofu/portainer/.terraform.lock.hcl
@@ -1,6 +1,43 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.56.0"
+  constraints = "6.56.0"
+  hashes = [
+    "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
+    "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",
+    "h1:2dvNShMZVY7phtwgAzwb71Ti89iS9Oe5Q30nMByg+3Y=",
+    "h1:34wj37Q0GYVYOpPZzJmWe7Cn0oLRLs0ayufm/D8sJow=",
+    "h1:3fSBwoUdMWy5bkzzlt38c3t2oehD8RGC+zmzFjLly0Q=",
+    "h1:48sjPpD0FP6TkRRdQiwzIbb9TC7/RCnc9UwZWpaFMIg=",
+    "h1:EoQDYEyKtxn8l6L6GJyoDAJcQ9jzG2afMB4x4zUX+2g=",
+    "h1:JsnLwJMWNwFM5bJVTs+sCn+nCbmgGFXHHjhaOLqU76A=",
+    "h1:OzyJEpEhKzbd6MrlOuXl0044PaHtN1yZt8pwmvvd36o=",
+    "h1:X5lyNLD4cRQLFQ4D7RZ8CHev7MNgxI04jiTaYiVbD/A=",
+    "h1:Xcz3FJq9rr9tydyRdNC115+nfjb+DhYI0minfttYCt4=",
+    "h1:Yo/FedZZFpeiJKuRV0kY8a4VrgXxo/9FaHEWL1LC1zg=",
+    "h1:fvDkPtOpGmppQVwEWWxG06aw+9x/cin45AXuzfreaLA=",
+    "h1:g/0wLy+9gp88CgU3NYAKtooRMex58Z/QKrHfo7QZCXI=",
+    "h1:vqJG9VI7EksPt0YsEc2RmgGwUCcDrdw3v484NIxqvkk=",
+    "zh:0df287675010e67011cd830a69fb8c81eb81b8cc82ec21f806bf5b70ffacb94c",
+    "zh:1b0a431e4a51be43b77dc5f790906567a0a6a9e683b442be0cd2758f1e1d5637",
+    "zh:1c58a0335198d558cb2ea83a42ef043b89f817c5e67a54a3746d3a47344ba602",
+    "zh:1ce5a623d2a2d9c006e0009fa67a9d486984abd3084648fcdd7997b7fc022233",
+    "zh:2380bc878d1127d75155df23f8fad4b64fe21db4856070dc084fcde80b856ca9",
+    "zh:51d77a6f1847fbf97874c976cf134b105abce8fce0beba38fc169ab5cfb7de66",
+    "zh:6364cac70a860c107b4a019aeb8c8afd9cb7e70bcd5a25ae62b74e27eaadeac2",
+    "zh:68e8d389804f6fc40fe5071093c52d41b82a18436be01ff75eba719d5c43286a",
+    "zh:82d4b24e9eb2e01568e0c0bc43c85686093d3c6f1a97461374c3009333f0522c",
+    "zh:b5845bd95ba758f6d411683bf14b5ee9208f31872d416f1aa82975e2ac31d696",
+    "zh:c228a7e9fab6319af525d78052f542504a042356ba1e71cd3c5f218c8b0fd7c4",
+    "zh:c5dd55276e518c6ab215e298091577ceb618ca405603885bb5e153b95d2e7d8c",
+    "zh:c6ceeb277f1897a0f813b913bf270db409f4fc3ec95d24238e5f5e71709edf7e",
+    "zh:f1e42b4c42faebd28f6040201760bfdd1e3391d858abd7586c7e513433e8a73d",
+    "zh:fff049bcd38e4cd82d526670e81aceb5f30d211c8b494221773737cade6e27c2",
+  ]
+}
+
 provider "registry.opentofu.org/infisical/infisical" {
   version     = "0.19.6"
   constraints = "0.19.6"

--- a/opentofu/portainer/README.md
+++ b/opentofu/portainer/README.md
@@ -141,7 +141,7 @@ versions can exist temporarily. The rule's prefix also covers old
    values to the existing ignored `local.auto.tfvars`:
 
    ```hcl
-   aws_region        = "us-east-1"
+   aws_region        = "aws-region"
    state_bucket_name = "replace-with-your-globally-unique-bucket-name"
    ```
 

--- a/opentofu/portainer/README.md
+++ b/opentofu/portainer/README.md
@@ -10,11 +10,13 @@ This directory is one OpenTofu root. Files are split by concern for readability:
 versions.tofu
 providers.tofu
 
+variables.aws.tofu
 variables.infisical.tofu
 variables.portainer.tofu
 variables.registries.tofu
 variables.stacks.tofu
 
+state_bucket.tofu
 infisical.portainer.tofu
 infisical.registries.tofu
 infisical.stack-env.tofu
@@ -59,6 +61,7 @@ infisical_dockerhub_registry_tokens_enabled = true
 
 Keep these in local tfvars:
 
+- AWS settings: `aws_region`, `state_bucket_name`, and optional `state_bucket_tags`
 - Infisical bootstrap/auth values: `infisical_project_id`, `infisical_env_slug`, `infisical_auth`, and optional `infisical_host`
 - Repository settings: `repository_url`, `repository_reference_name`, and any stack-specific reference overrides
 - Non-secret Portainer object shape: `dockerhub_registries`, Git credential IDs, and stack behavior toggles
@@ -85,6 +88,132 @@ If the existing stack uses a saved Portainer Git credential, set:
 ```hcl
 git_repository_authentication = true
 repository_git_credential_id  = 1
+```
+
+## AWS S3 State Backend
+
+This root stores state at `s3://<bucket>/portainer/terraform.tfstate` and uses
+OpenTofu's native S3 lock file. The bucket and region are supplied as partial
+backend configuration so credentials and deployment-specific values are not
+committed.
+
+The same root manages its backend bucket. The bucket resource has
+`prevent_destroy = true`, versioning, SSE-S3 encryption, bucket-owner-enforced
+ownership, all bucket-level public access blocks enabled, and lifecycle
+retention for five state snapshots. Before deleting or replacing this bucket,
+migrate the state to another backend.
+
+The lifecycle rule retains the current state object and its four newest
+noncurrent versions. Older noncurrent versions become eligible for permanent
+deletion after one day. S3 requires a positive noncurrent age, so more than five
+versions can exist temporarily. The rule's prefix also covers old
+`terraform.tfstate.tflock` versions created by native S3 state locking.
+
+### One-time migration and import
+
+1. In AWS, manually create a globally unique S3 bucket. Create it in the region
+   you intend to use and enable:
+
+   - Bucket versioning
+   - SSE-S3 (`AES256`) default encryption
+   - Bucket owner enforced object ownership
+   - All four Block Public Access settings
+
+   Do not upload a state file or create a lifecycle rule manually. OpenTofu will
+   create the lifecycle rule after the bucket settings are imported.
+
+2. Authenticate to AWS with the profile or environment used by both OpenTofu's
+   S3 backend and AWS provider. Do not put AWS credentials in either backend
+   configuration or tfvars. For example:
+
+   ```shell
+   export AWS_PROFILE=homelab
+   aws sts get-caller-identity
+   ```
+
+3. From `opentofu/portainer`, create the ignored partial backend configuration:
+
+   ```shell
+   cp backend.s3.tfbackend.example backend.s3.tfbackend
+   ```
+
+   Replace the example bucket and region in `backend.s3.tfbackend`. Add the same
+   values to the existing ignored `local.auto.tfvars`:
+
+   ```hcl
+   aws_region        = "us-east-1"
+   state_bucket_name = "replace-with-your-globally-unique-bucket-name"
+   ```
+
+   The backend file and provider variables are separate because backend blocks
+   cannot refer to input variables.
+
+4. Make a protected backup copy of the existing local `terraform.tfstate`
+   outside this repository. State contains secrets; do not commit or share the
+   backup.
+
+5. Migrate the complete existing state to S3:
+
+   ```shell
+   tofu init -migrate-state -backend-config=backend.s3.tfbackend
+   ```
+
+   Review the source and destination in OpenTofu's prompt before confirming the
+   migration. Do not run `tofu import` before this step.
+
+6. Verify that OpenTofu can read the migrated state and that the S3 object
+   exists:
+
+   ```shell
+   tofu state list
+   aws s3api head-object \
+     --bucket replace-with-your-globally-unique-bucket-name \
+     --key portainer/terraform.tfstate
+   ```
+
+7. Import the manually configured bucket and each existing bucket setting into
+   the now-remote state:
+
+   ```shell
+   tofu import aws_s3_bucket.portainer_state replace-with-your-globally-unique-bucket-name
+   tofu import aws_s3_bucket_ownership_controls.portainer_state replace-with-your-globally-unique-bucket-name
+   tofu import aws_s3_bucket_public_access_block.portainer_state replace-with-your-globally-unique-bucket-name
+   tofu import aws_s3_bucket_server_side_encryption_configuration.portainer_state replace-with-your-globally-unique-bucket-name
+   tofu import aws_s3_bucket_versioning.portainer_state replace-with-your-globally-unique-bucket-name
+   ```
+
+   If a setting was not created manually, its import will report that no remote
+   object exists. Leave that resource unimported; the next plan will propose
+   creating the missing setting. If you already created a lifecycle
+   configuration manually, import it as well:
+
+   ```shell
+   tofu import aws_s3_bucket_lifecycle_configuration.portainer_state replace-with-your-globally-unique-bucket-name
+   ```
+
+   An S3 bucket has one lifecycle configuration. Importing or applying this
+   resource makes OpenTofu authoritative for the bucket's complete lifecycle
+   rule set.
+
+8. Review the result:
+
+   ```shell
+   tofu plan
+   ```
+
+   Expect only intentional differences such as the configured tags or a
+   manually omitted bucket setting. Apply only after the plan is understood.
+
+The AWS identity used by the backend needs `s3:ListBucket` on the bucket and
+`s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on both
+`portainer/terraform.tfstate` and `portainer/terraform.tfstate.tflock`. Managing
+the bucket resources also requires the corresponding S3 configuration and
+tagging permissions.
+
+For later backend configuration changes, rerun:
+
+```shell
+tofu init -reconfigure -backend-config=backend.s3.tfbackend
 ```
 
 ## Infisical Provider Config

--- a/opentofu/portainer/backend.s3.tfbackend.example
+++ b/opentofu/portainer/backend.s3.tfbackend.example
@@ -1,0 +1,2 @@
+bucket = "replace-with-your-globally-unique-bucket-name"
+region = "aws-region"

--- a/opentofu/portainer/providers.tofu
+++ b/opentofu/portainer/providers.tofu
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+}
+
 provider "portainer" {
   endpoint        = local.portainer_endpoint
   api_key         = local.portainer_api_key

--- a/opentofu/portainer/state_bucket.tofu
+++ b/opentofu/portainer/state_bucket.tofu
@@ -1,0 +1,69 @@
+resource "aws_s3_bucket" "portainer_state" {
+  bucket        = var.state_bucket_name
+  force_destroy = false
+
+  tags = merge(var.state_bucket_tags, {
+    ManagedBy = "OpenTofu"
+    Purpose   = "Portainer OpenTofu state"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "portainer_state" {
+  bucket = aws_s3_bucket.portainer_state.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "portainer_state" {
+  bucket = aws_s3_bucket.portainer_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "portainer_state" {
+  bucket = aws_s3_bucket.portainer_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "portainer_state" {
+  bucket = aws_s3_bucket.portainer_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "portainer_state" {
+  bucket = aws_s3_bucket.portainer_state.id
+
+  depends_on = [aws_s3_bucket_versioning.portainer_state]
+
+  rule {
+    id     = "retain-five-state-versions"
+    status = "Enabled"
+
+    filter {
+      prefix = "portainer/terraform.tfstate"
+    }
+
+    noncurrent_version_expiration {
+      # The current version plus four noncurrent versions retains five snapshots.
+      newer_noncurrent_versions = 4
+      noncurrent_days           = 1
+    }
+  }
+}

--- a/opentofu/portainer/terraform.tfvars.example
+++ b/opentofu/portainer/terraform.tfvars.example
@@ -1,3 +1,11 @@
+aws_region        = "aws-region"
+state_bucket_name = "replace-with-your-globally-unique-bucket-name"
+
+# Optional tags for the state bucket.
+# state_bucket_tags = {
+#   Environment = "homelab"
+# }
+
 repository_url            = "https://github.com/user/project.git"
 repository_reference_name = "refs/heads/main"
 

--- a/opentofu/portainer/variables.aws.tofu
+++ b/opentofu/portainer/variables.aws.tofu
@@ -1,0 +1,15 @@
+variable "aws_region" {
+  description = "AWS region containing the S3 bucket used for OpenTofu state."
+  type        = string
+}
+
+variable "state_bucket_name" {
+  description = "Globally unique name of the S3 bucket used for OpenTofu state."
+  type        = string
+}
+
+variable "state_bucket_tags" {
+  description = "Additional tags to apply to the OpenTofu state bucket."
+  type        = map(string)
+  default     = {}
+}

--- a/opentofu/portainer/versions.tofu
+++ b/opentofu/portainer/versions.tofu
@@ -5,7 +5,18 @@ language {
 }
 
 terraform {
+  backend "s3" {
+    key          = "portainer/terraform.tfstate"
+    encrypt      = true
+    use_lockfile = true
+  }
+
   required_providers {
+    aws = {
+      source  = "registry.opentofu.org/hashicorp/aws"
+      version = "6.56.0"
+    }
+
     infisical = {
       source  = "registry.opentofu.org/infisical/infisical"
       version = "0.19.6"


### PR DESCRIPTION
## Summary

- Configure an AWS S3 backend for the Portainer OpenTofu state
- Enable native S3 state locking with `use_lockfile`
- Manage the backend bucket through OpenTofu after initial manual creation
- Enable bucket versioning, SSE-S3 encryption, owner-enforced ownership, and public-access blocking
- Prevent accidental bucket destruction
- Retain five state snapshots through an S3 lifecycle rule
- Add an ignored partial backend configuration and documented migration/import procedure

## State retention

The lifecycle rule retains the current state version and four noncurrent versions. Older noncurrent versions become eligible for permanent deletion after one day.

The rule also covers old native S3 lock-file versions.

## Migration

The documented bootstrap process is:

1. Create the S3 bucket manually with the required protections
2. Configure the local backend and AWS variables
3. Migrate the existing local state with `tofu init -migrate-state`
4. Import the bucket and its existing configuration resources
5. Review the resulting OpenTofu plan

## Validation

- `tofu fmt -check` passed
- `tofu validate` passed
- `git diff --check` passed

The real `backend.s3.tfbackend`, local tfvars, state files, and AWS credentials remain ignored.