### PR TITLE
Add Alpine Slim Draw.io Image

### DIFF
--- a/.github/workflows/docker-build-push-ghcr.yml
+++ b/.github/workflows/docker-build-push-ghcr.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths:
-      - 'Dockerfiles/*/Dockerfile'
+      - 'Dockerfiles/**'
   push:
     branches:
       - main
     paths:
-      - 'Dockerfiles/*/Dockerfile'
+      - 'Dockerfiles/**'
   workflow_dispatch:
     inputs:
       manual_directory:
@@ -49,6 +49,7 @@ jobs:
           set -euo pipefail
 
           declare -a DIRECTORIES=()
+          declare -A SEEN_DIRECTORIES=()
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             MANUAL_DIRECTORY="${{ github.event.inputs.manual_directory }}"
@@ -64,33 +65,41 @@ jobs:
 
             DIRECTORIES=("$MANUAL_DIRECTORY")
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            mapfile -t CHANGED_FILES < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD | grep -E "^Dockerfiles/[^/]+/Dockerfile$" || true)
+            mapfile -t CHANGED_FILES < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD | grep -E "^Dockerfiles/[^/]+/" || true)
             if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
-              echo "No Dockerfiles were modified. Exiting."
+              echo "No Docker build contexts were modified. Exiting."
               echo "directories=[]" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
             for FILE in "${CHANGED_FILES[@]}"; do
-              if [ -f "$FILE" ]; then
-                DIRECTORIES+=("$(dirname "$FILE")")
-              else
-                echo "Skipping deleted Dockerfile: $FILE"
+              DIR=$(cut -d/ -f1-2 <<< "$FILE")
+              if [ ! -f "$DIR/Dockerfile" ]; then
+                echo "Skipping context without a Dockerfile: $DIR"
+                continue
+              fi
+              if [ -z "${SEEN_DIRECTORIES[$DIR]+x}" ]; then
+                DIRECTORIES+=("$DIR")
+                SEEN_DIRECTORIES["$DIR"]=1
               fi
             done
           else
-            mapfile -t CHANGED_FILES < <(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -E "^Dockerfiles/[^/]+/Dockerfile$" || true)
+            mapfile -t CHANGED_FILES < <(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -E "^Dockerfiles/[^/]+/" || true)
             if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
-              echo "No Dockerfiles were modified. Exiting."
+              echo "No Docker build contexts were modified. Exiting."
               echo "directories=[]" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
             for FILE in "${CHANGED_FILES[@]}"; do
-              if [ -f "$FILE" ]; then
-                DIRECTORIES+=("$(dirname "$FILE")")
-              else
-                echo "Skipping deleted Dockerfile: $FILE"
+              DIR=$(cut -d/ -f1-2 <<< "$FILE")
+              if [ ! -f "$DIR/Dockerfile" ]; then
+                echo "Skipping context without a Dockerfile: $DIR"
+                continue
+              fi
+              if [ -z "${SEEN_DIRECTORIES[$DIR]+x}" ]; then
+                DIRECTORIES+=("$DIR")
+                SEEN_DIRECTORIES["$DIR"]=1
               fi
             done
           fi

--- a/Dockerfiles/drawio/Caddyfile
+++ b/Dockerfiles/drawio/Caddyfile
@@ -1,0 +1,32 @@
+{
+	admin off
+	auto_https off
+	persist_config off
+
+	# TLS is terminated by the reverse proxy, so the backend only needs h1.
+	servers {
+		protocols h1
+	}
+}
+
+http://:8080 {
+	root * /srv
+
+	# Keep the container health check independent of application assets.
+	respond /healthz 200
+
+	# These directories are removed during the build. Keep this rule as
+	# defense in depth in case the source layout changes in a future release.
+	@sensitive path /WEB-INF/* /META-INF/*
+	respond @sensitive 404
+
+	header {
+		-Server
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "no-referrer"
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+	}
+
+	encode zstd gzip
+	file_server
+}

--- a/Dockerfiles/drawio/Dockerfile
+++ b/Dockerfiles/drawio/Dockerfile
@@ -1,0 +1,35 @@
+# build-image: drawio
+# build-tag-suffix: -alpine-custom
+# build-version-source
+FROM jgraph/drawio:31.1.5@sha256:9dfa053d1fe2724f824c61eac8b8bb2e93acc8ecb23dea58b8c11028127c572c AS upstream
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS source
+
+# The upstream image has already built and extracted the WAR. Copy only its
+# webapp into a disposable stage, then remove its server-side components.
+COPY --from=upstream /usr/local/tomcat/webapps/draw/ /src/
+RUN rm -rf /src/WEB-INF /src/META-INF
+
+# Replace the public-build defaults with a device-only configuration that does
+# not call draw.io's cloud integrations or external export service.
+COPY PreConfig.js /src/js/PreConfig.js
+
+FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+
+LABEL maintainer="draw.io Ltd" \
+      org.opencontainers.image.authors="draw.io Ltd" \
+      org.opencontainers.image.url="https://www.drawio.com" \
+      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
+
+RUN addgroup -S caddy \
+    && adduser -S -D -H -s /sbin/nologin -G caddy caddy
+
+COPY --chown=caddy:caddy Caddyfile /etc/caddy/Caddyfile
+COPY --from=source --chown=caddy:caddy /src/ /srv/
+
+USER caddy
+WORKDIR /srv
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1

--- a/Dockerfiles/drawio/PreConfig.js
+++ b/Dockerfiles/drawio/PreConfig.js
@@ -1,0 +1,32 @@
+/**
+ * Local, static draw.io configuration.
+ *
+ * TLS is terminated by the reverse proxy. Diagrams are opened from and saved
+ * to the user's device, and integrations that require external services are
+ * disabled.
+ */
+window.DRAWIO_PUBLIC_BUILD = true;
+window.EXPORT_URL = null;
+window.DRAWIO_BASE_URL = null;
+window.DRAWIO_VIEWER_URL = null;
+window.DRAWIO_LIGHTBOX_URL = null;
+window.DRAW_MATH_URL = 'math4/es5';
+window.DRAWIO_CONFIG = {
+  lockdown: true,
+  enableExportUrl: false,
+  override: true,
+  // This is a configuration schema revision, not the draw.io release.
+  // Increment it only when browser-stored settings must be reset.
+  version: 'homelab-static-v1'
+};
+
+urlParams['local'] = '1';
+urlParams['plugins'] = '0';
+urlParams['sync'] = 'manual';
+urlParams['gapi'] = '0';
+urlParams['db'] = '0';
+urlParams['od'] = '0';
+urlParams['ms365'] = '0';
+urlParams['tr'] = '0';
+urlParams['gh'] = '0';
+urlParams['gl'] = '0';


### PR DESCRIPTION
## Summary

Adds a lightweight, static draw.io image for the homelab, served by Caddy instead of Tomcat.

### Changes

- Adds `Dockerfiles/drawio/` containing:
  - Multi-stage Dockerfile using draw.io `31.1.5`
  - Alpine-based Caddy runtime
  - Device-only draw.io configuration
  - Caddy configuration for HTTP behind a TLS-terminating reverse proxy
- Removes server-side components (`WEB-INF` and `META-INF`) from the final application.
- Disables cloud integrations, plugins, synchronization, and external export services.
- Runs Caddy as a non-root user.
- Pins all base images by tag and digest for Renovate management and reproducible builds.
- Publishes the image as:
  - `drawio:31.1.5-alpine-custom`
- Updates the Docker build workflow to:
  - Trigger for all changes under `Dockerfiles/**`
  - Detect changes to supporting files such as `Caddyfile` and `PreConfig.js`
  - Deduplicate build contexts when multiple files change
  - Skip removed contexts without a Dockerfile

## Testing

- Successfully built for:
  - `linux/amd64`
  - `linux/arm64`
- Verified `/` and `/healthz` return HTTP 200.
- Verified required draw.io static assets are present.
- Verified `WEB-INF` and `META-INF` are absent.
- Verified Caddy runs as a non-root user.
- Verified only HTTP/1.1 is enabled behind the reverse proxy.
- Validated workflow YAML and Dockerfile version extraction.
- Confirmed generated image tag:
  - `drawio:31.1.5-alpine-custom`