### PR TITLE
Fix drawio custom image

### DIFF
--- a/Dockerfiles/drawio/Dockerfile
+++ b/Dockerfiles/drawio/Dockerfile
@@ -4,6 +4,11 @@
 FROM jgraph/drawio:31.1.5@sha256:9dfa053d1fe2724f824c61eac8b8bb2e93acc8ecb23dea58b8c11028127c572c AS upstream
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS source
 
+LABEL maintainer="mmichalak-swe" \
+      org.opencontainers.image.authors="mmichalak-swe" \
+      org.opencontainers.image.url="https://github.com/mmichalak-swe/homelab-gitops" \
+      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
+
 # The upstream image has already built and extracted the WAR. Copy only its
 # webapp into a disposable stage, then remove its server-side components.
 COPY --from=upstream /usr/local/tomcat/webapps/draw/ /src/
@@ -14,11 +19,6 @@ RUN rm -rf /src/WEB-INF /src/META-INF
 COPY PreConfig.js /src/js/PreConfig.js
 
 FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
-
-LABEL maintainer="mmichalak-swe" \
-      org.opencontainers.image.authors="mmichalak-swe" \
-      org.opencontainers.image.url="https://github.com/mmichalak-swe/homelab-gitops" \
-      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
 
 # The official image grants Caddy CAP_NET_BIND_SERVICE so it can bind ports
 # below 1024. This image listens on 8080, and retaining that file capability

--- a/Dockerfiles/drawio/Dockerfile
+++ b/Dockerfiles/drawio/Dockerfile
@@ -15,16 +15,24 @@ COPY PreConfig.js /src/js/PreConfig.js
 
 FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
 
-LABEL maintainer="draw.io Ltd" \
-      org.opencontainers.image.authors="draw.io Ltd" \
-      org.opencontainers.image.url="https://www.drawio.com" \
+LABEL maintainer="mmichalak-swe" \
+      org.opencontainers.image.authors="mmichalak-swe" \
+      org.opencontainers.image.url="https://github.com/mmichalak-swe/homelab-gitops" \
       org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
 
-RUN addgroup -S caddy \
+# The official image grants Caddy CAP_NET_BIND_SERVICE so it can bind ports
+# below 1024. This image listens on 8080, and retaining that file capability
+# prevents exec when the runtime uses cap_drop: [ALL] and no-new-privileges.
+RUN if getcap /usr/bin/caddy | grep -q .; then setcap -r /usr/bin/caddy; fi \
+    && test -z "$(getcap /usr/bin/caddy)" \
+    && addgroup -S caddy \
     && adduser -S -D -H -s /sbin/nologin -G caddy caddy
 
 COPY --chown=caddy:caddy Caddyfile /etc/caddy/Caddyfile
 COPY --from=source --chown=caddy:caddy /src/ /srv/
+
+ENV XDG_CONFIG_HOME=/tmp/caddy-config \
+    XDG_DATA_HOME=/tmp/caddy-data
 
 USER caddy
 WORKDIR /srv

--- a/hosts/6194cicero-gmk-g3/drawio/compose.yml
+++ b/hosts/6194cicero-gmk-g3/drawio/compose.yml
@@ -16,11 +16,11 @@ services:
     expose:
       - 8080
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1"]
       interval: 30s
-      timeout: 10s
+      timeout: 3s
       retries: 3
-      start_period: 10s
+      start_period: 5s
     hostname: drawio
     image: ghcr.io/mmichalak-swe/homelab-gitops/drawio:31.1.5-alpine-custom@sha256:ec529041139f63656063dae2d70e2dae6540920aec01ebb734d92aa38ac92125
     networks:


### PR DESCRIPTION
## Summary

Fixes the custom draw.io container failing to start under its hardened Linux security configuration and aligns the Compose health check with the image.

## Changes

- Removes Caddy’s unnecessary `CAP_NET_BIND_SERVICE` file capability, allowing execution with:
  - `cap_drop: [ALL]`
  - `no-new-privileges:true`
- Moves Caddy’s ephemeral configuration and data directories to the writable `/tmp` tmpfs.
- Updates image metadata to reference the homelab repository and maintainer.
- Changes the Compose health check to use the dedicated `/healthz` endpoint.
- Aligns Compose health-check timing with the Dockerfile.

## Testing

- Verified startup with all capabilities dropped.
- Verified startup with `no-new-privileges` and a read-only root filesystem.
- Confirmed the container reports healthy.
- Confirmed startup logs contain no capability or read-only storage errors.