### PR TITLE
Reduce draw.io custom image size

### DIFF
--- a/Dockerfiles/drawio/Dockerfile
+++ b/Dockerfiles/drawio/Dockerfile
@@ -1,13 +1,12 @@
 # build-image: drawio
 # build-tag-suffix: -alpine-custom
+
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS alpine-base
+
 # build-version-source
 FROM jgraph/drawio:31.1.5@sha256:9dfa053d1fe2724f824c61eac8b8bb2e93acc8ecb23dea58b8c11028127c572c AS upstream
-FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS source
 
-LABEL maintainer="mmichalak-swe" \
-      org.opencontainers.image.authors="mmichalak-swe" \
-      org.opencontainers.image.url="https://github.com/mmichalak-swe/homelab-gitops" \
-      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
+FROM alpine-base AS source
 
 # The upstream image has already built and extracted the WAR. Copy only its
 # webapp into a disposable stage, then remove its server-side components.
@@ -18,16 +17,26 @@ RUN rm -rf /src/WEB-INF /src/META-INF
 # not call draw.io's cloud integrations or external export service.
 COPY PreConfig.js /src/js/PreConfig.js
 
-FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
+FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648 AS caddy-source
 
-# The official image grants Caddy CAP_NET_BIND_SERVICE so it can bind ports
-# below 1024. This image listens on 8080, and retaining that file capability
-# prevents exec when the runtime uses cap_drop: [ALL] and no-new-privileges.
-RUN if getcap /usr/bin/caddy | grep -q .; then setcap -r /usr/bin/caddy; fi \
-    && test -z "$(getcap /usr/bin/caddy)" \
+# A normal copy does not preserve Caddy's CAP_NET_BIND_SERVICE extended
+# attribute. Verify that the capability-free binary is safe to copy into the
+# final image, which listens on unprivileged port 8080.
+RUN cp /usr/bin/caddy /caddy \
+    && test -z "$(getcap /caddy)"
+
+FROM alpine-base AS runtime
+
+LABEL maintainer="mmichalak-swe" \
+      org.opencontainers.image.authors="mmichalak-swe" \
+      org.opencontainers.image.url="https://github.com/mmichalak-swe/homelab-gitops" \
+      org.opencontainers.image.source="https://github.com/jgraph/docker-drawio"
+
+RUN apk add --no-cache ca-certificates mailcap \
     && addgroup -S caddy \
     && adduser -S -D -H -s /sbin/nologin -G caddy caddy
 
+COPY --from=caddy-source --chown=root:root --chmod=0755 /caddy /usr/bin/caddy
 COPY --chown=caddy:caddy Caddyfile /etc/caddy/Caddyfile
 COPY --from=source --chown=caddy:caddy /src/ /srv/
 
@@ -41,3 +50,5 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1
+
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
## Summary

Refactors the draw.io Dockerfile to use Alpine as the final runtime image and copy the Caddy binary from the official Caddy image.

This avoids modifying Caddy in place, which previously duplicated its binary in an additional image layer and increased the uncompressed image size by approximately 55 MB.

## Changes

- Adds a shared Alpine 3.24.1 base stage.
- Uses the official Caddy image only as a binary source.
- Copies Caddy without its low-port file capability.
- Verifies the copied binary is capability-free.
- Recreates the required Caddy user, runtime packages, working directory, and command.
- Moves OCI labels onto the final runtime stage.
- Retains the existing non-root user, health check, and port 8080 configuration.

## Validation

- Built successfully for `linux/amd64` and `linux/arm64`.
- Starts successfully with all capabilities dropped and `no-new-privileges`.
- Runs with a read-only root filesystem.
- Container health check reports healthy.
- Reduced the local uncompressed image size to approximately 198 MB.