### PR TITLE
Fix Portainer container logs and increase logging level

### DIFF
--- a/hosts/6194cicero-raspberrypi/portainer/compose.yml
+++ b/hosts/6194cicero-raspberrypi/portainer/compose.yml
@@ -69,7 +69,7 @@ services:
       - EXEC=0
       - IMAGES=1
       - INFO=1
-      - LOG_LEVEL=notice
+      - LOG_LEVEL=info
       - NETWORKS=1
       - NODES=0
       - PING=1

--- a/hosts/6194cicero-raspberrypi/portainer/compose.yml
+++ b/hosts/6194cicero-raspberrypi/portainer/compose.yml
@@ -57,6 +57,7 @@ services:
       - ALL
     container_name: portainer-socket-proxy
     environment:
+      - ALLOW_LOGS=1
       - AUTH=0
       - BUILD=0
       - COMMIT=0


### PR DESCRIPTION
Add `ALLOW_LOGS` to enable Portainer to see container logs
Update `LOG_LEVEL` from `notice` to `info` to see individual requests in the portainer-socket-proxy logs for troubleshooting